### PR TITLE
feat: add contract schema methods

### DIFF
--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -3,6 +3,7 @@ import {GenLayerTransaction, TransactionHash, TransactionStatus} from "./transac
 import {SimulatorChain} from "./chains";
 import {Address, Account} from "./accounts";
 import {CalldataEncodable} from "./calldata";
+import {ContractSchema} from "./contracts";
 
 export type GenLayerMethod =
   | {method: "sim_fundAccount"; params: [address: string, amount: number]}
@@ -50,4 +51,6 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
       hash: TransactionHash;
       status?: TransactionStatus;
     }) => Promise<GenLayerTransaction>;
+    getContractSchema: (address: string) => Promise<ContractSchema>;
+    getContractSchemaForCode: (contractCode: string) => Promise<ContractSchema>;
   };

--- a/tests/client.test-d.ts
+++ b/tests/client.test-d.ts
@@ -8,26 +8,32 @@ test("type checks", () => {
     account: createAccount(generatePrivateKey()),
   });
 
+  const exampleAddress = "0x1234567890123456789012345678901234567890";
+
   // This should fail type checking - "whatever" is not a valid filter
   // @ts-expect-error "whatever" is not a valid filter type
   void client.request({
     method: "sim_getTransactionsForAddress",
-    params: ["0x1234567890123456789012345678901234567890", "whatever"],
+    params: [exampleAddress, "whatever"],
   });
 
   // This should pass type checking - "all", "to" and "from" are valid filters
   void client.request({
     method: "sim_getTransactionsForAddress",
-    params: ["0x1234567890123456789012345678901234567890", "all"],
+    params: [exampleAddress, "all"],
   });
 
   void client.request({
     method: "sim_getTransactionsForAddress",
-    params: ["0x1234567890123456789012345678901234567890", "to"],
+    params: [exampleAddress, "to"],
   });
 
   void client.request({
     method: "sim_getTransactionsForAddress",
-    params: ["0x1234567890123456789012345678901234567890", "from"],
+    params: [exampleAddress, "from"],
   });
+
+  void client.getContractSchema(exampleAddress);
+
+  void client.getContractSchemaForCode("class SomeContract...");
 });


### PR DESCRIPTION
# What

adds getContractSchema and getContractSchemaForCode to the genlayer client type

# Why

They weren't configured properly.
![image](https://github.com/user-attachments/assets/342a7407-0794-45de-8a05-842e4eb055eb)


# Testing done

added type tests

# Decisions made


# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# User facing release notes

Now you can use `getContractSchema` and `getContractSchemaForCode` from your GenLayer client
