### PR TITLE
feat: support leader only execution of write/deploy transactions

### DIFF
--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -43,8 +43,14 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
       functionName: string;
       args: CalldataEncodable[];
       value: bigint;
+      leader_only?: boolean;
     }) => Promise<any>;
-    deployContract: (args: {account?: Account; code: string; args: CalldataEncodable[]}) => Promise<any>;
+    deployContract: (args: {
+      account?: Account;
+      code: string;
+      args: CalldataEncodable[];
+      leader_only?: boolean;
+    }) => Promise<any>;
     getTransaction: (args: {hash: TransactionHash}) => Promise<GenLayerTransaction>;
     getCurrentNonce: (args: {address: string}) => Promise<number>;
     waitForTransactionReceipt: (args: {


### PR DESCRIPTION
Fixes #24 

# What

- added support for leader only parameter in write and deploy calls

# Why

- to add more value to local developers

# Testing done

- tested the new feature

# Decisions made

- had to split the serializing/encoding of params in two steps in the write calls to allow passing the new parameter

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- You can try with the simulator by creating a symlink with the library and try with/without leader only toggle enabled in the UI

# User facing release notes

- Added support for the leader only (fast) execution of write methods and contract deployments in local environments
