### PR TITLE
fix: readContract return type

### DIFF
--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -26,7 +26,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     address: Address;
     functionName: string;
     args: CalldataEncodable[];
-  }): Promise<any> => {
+  }): Promise<unknown> => {
     const {account, address, functionName, args: params} = args;
     const encodedData = encodeAndSerialize({method: functionName, args: params});
 

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -39,7 +39,7 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
       address: Address;
       functionName: string;
       args: CalldataEncodable[];
-    }) => Promise<`0x${string}`>;
+    }) => Promise<unknown>;
     writeContract: (args: {
       account?: Account;
       address: Address;


### PR DESCRIPTION
my bad from a previous PR. `readContract` can return anything from the contract