### PR TITLE
chore: update waitForTransactionReceipt to use `ACCEPTED` as default

### DIFF
--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -7,7 +7,7 @@ import {SimulatorChain} from "@/types";
 export const transactionActions = (client: GenLayerClient<SimulatorChain>) => ({
   waitForTransactionReceipt: async ({
     hash,
-    status = TransactionStatus.FINALIZED,
+    status = TransactionStatus.ACCEPTED,
     interval = transactionsConfig.waitInterval,
     retries = transactionsConfig.retries,
   }: {


### PR DESCRIPTION
Since now the local network handles appeals, we probably want de default to be to wait for `ACCEPTED` to not wait for an hour