### PR TITLE
fix: added GenVM decoder to readContract method

### DIFF
--- a/src/abi/calldata/consts.ts
+++ b/src/abi/calldata/consts.ts
@@ -1,0 +1,14 @@
+export const BITS_IN_TYPE = 3;
+
+export const TYPE_SPECIAL = 0;
+export const TYPE_PINT = 1;
+export const TYPE_NINT = 2;
+export const TYPE_BYTES = 3;
+export const TYPE_STR = 4;
+export const TYPE_ARR = 5;
+export const TYPE_MAP = 6;
+
+export const SPECIAL_NULL = (0 << BITS_IN_TYPE) | TYPE_SPECIAL;
+export const SPECIAL_FALSE = (1 << BITS_IN_TYPE) | TYPE_SPECIAL;
+export const SPECIAL_TRUE = (2 << BITS_IN_TYPE) | TYPE_SPECIAL;
+export const SPECIAL_ADDR = (3 << BITS_IN_TYPE) | TYPE_SPECIAL;

--- a/src/abi/calldata/decoder.ts
+++ b/src/abi/calldata/decoder.ts
@@ -1,0 +1,86 @@
+import type {CalldataEncodable} from "../../types/calldata";
+import {Address} from "../../types/calldata";
+import * as consts from "./consts";
+
+function readULeb128(data: Uint8Array, index: {i: number}): bigint {
+  let res: bigint = 0n;
+  let accum = 0n;
+  let shouldContinue = true;
+  while (shouldContinue) {
+    const byte = data[index.i];
+    index.i++;
+    const rest = byte & 0x7f;
+    res += BigInt(rest) * (1n << accum);
+    accum += 7n;
+    shouldContinue = byte >= 128;
+  }
+  return res;
+}
+
+function decodeImpl(data: Uint8Array, index: {i: number}): CalldataEncodable {
+  const cur = readULeb128(data, index);
+  switch (cur) {
+    case BigInt(consts.SPECIAL_NULL):
+      return null;
+    case BigInt(consts.SPECIAL_TRUE):
+      return true;
+    case BigInt(consts.SPECIAL_FALSE):
+      return false;
+    case BigInt(consts.SPECIAL_ADDR): {
+      const res = data.slice(index.i, index.i + 20);
+      index.i += 20;
+      return new Address(res);
+    }
+  }
+  const type = Number(cur & 0xffn) & ((1 << consts.BITS_IN_TYPE) - 1);
+  const rest = cur >> BigInt(consts.BITS_IN_TYPE);
+  switch (type) {
+    case consts.TYPE_BYTES: {
+      const ret = data.slice(index.i, index.i + Number(rest));
+      index.i += Number(rest);
+      return ret;
+    }
+    case consts.TYPE_PINT:
+      return rest;
+    case consts.TYPE_NINT:
+      return -1n - rest;
+    case consts.TYPE_STR: {
+      const ret = data.slice(index.i, index.i + Number(rest));
+      index.i += Number(rest);
+      return new TextDecoder("utf-8").decode(ret);
+    }
+    case consts.TYPE_ARR: {
+      const ret = [] as CalldataEncodable[];
+      let elems = rest;
+      while (elems > 0) {
+        elems--;
+        ret.push(decodeImpl(data, index));
+      }
+      return ret;
+    }
+    case consts.TYPE_MAP: {
+      const ret = new Map<string, CalldataEncodable>();
+      let elems = rest;
+      while (elems > 0) {
+        elems--;
+        const strLen = Number(readULeb128(data, index));
+        const key = data.slice(index.i, index.i + strLen);
+        index.i += strLen;
+        const keyStr = new TextDecoder("utf-8").decode(key);
+        ret.set(keyStr, decodeImpl(data, index));
+      }
+      return ret;
+    }
+    default:
+      throw new Error(`can't decode type from ${type} rest is ${rest} at pos ${index.i}`);
+  }
+}
+
+export function decode(data: Uint8Array): CalldataEncodable {
+  const index = {i: 0};
+  const res = decodeImpl(data, index);
+  if (index.i !== data.length) {
+    throw new Error("some data left");
+  }
+  return res;
+}

--- a/src/abi/calldata/encoder.ts
+++ b/src/abi/calldata/encoder.ts
@@ -1,21 +1,8 @@
-import {toHex, toRlp} from "viem";
+import {toHex} from "viem";
+import {toRlp} from "viem";
 import type {CalldataEncodable, TransactionDataElement} from "../../types/calldata";
 import {Address} from "../../types/calldata";
-
-const BITS_IN_TYPE = 3;
-
-const TYPE_SPECIAL = 0;
-const TYPE_PINT = 1;
-const TYPE_NINT = 2;
-const TYPE_BYTES = 3;
-const TYPE_STR = 4;
-const TYPE_ARR = 5;
-const TYPE_MAP = 6;
-
-const SPECIAL_NULL = (0 << BITS_IN_TYPE) | TYPE_SPECIAL;
-const SPECIAL_FALSE = (1 << BITS_IN_TYPE) | TYPE_SPECIAL;
-const SPECIAL_TRUE = (2 << BITS_IN_TYPE) | TYPE_SPECIAL;
-const SPECIAL_ADDR = (3 << BITS_IN_TYPE) | TYPE_SPECIAL;
+import * as consts from "./consts";
 
 function reportError(msg: string, data: CalldataEncodable): never {
   throw new Error(`invalid calldata input '${data}'`);
@@ -37,15 +24,15 @@ function writeNum(to: number[], data: bigint) {
 }
 
 function encodeNumWithType(to: number[], data: bigint, type: number) {
-  const res = (data << BigInt(BITS_IN_TYPE)) | BigInt(type);
+  const res = (data << BigInt(consts.BITS_IN_TYPE)) | BigInt(type);
   writeNum(to, res);
 }
 
 function encodeNum(to: number[], data: bigint) {
   if (data >= 0n) {
-    encodeNumWithType(to, data, TYPE_PINT);
+    encodeNumWithType(to, data, consts.TYPE_PINT);
   } else {
-    encodeNumWithType(to, -data - 1n, TYPE_NINT);
+    encodeNumWithType(to, -data - 1n, consts.TYPE_NINT);
   }
 }
 
@@ -76,7 +63,7 @@ function encodeMap(to: number[], arr: Iterable<[string, CalldataEncodable]>) {
     }
   }
 
-  encodeNumWithType(to, BigInt(newEntries.length), TYPE_MAP);
+  encodeNumWithType(to, BigInt(newEntries.length), consts.TYPE_MAP);
   for (const [, k, v] of newEntries) {
     writeNum(to, BigInt(k.length));
     for (const c of k) {
@@ -88,15 +75,15 @@ function encodeMap(to: number[], arr: Iterable<[string, CalldataEncodable]>) {
 
 function encodeImpl(to: number[], data: CalldataEncodable) {
   if (data === null || data === undefined) {
-    to.push(SPECIAL_NULL);
+    to.push(consts.SPECIAL_NULL);
     return;
   }
   if (data === true) {
-    to.push(SPECIAL_TRUE);
+    to.push(consts.SPECIAL_TRUE);
     return;
   }
   if (data === false) {
-    to.push(SPECIAL_FALSE);
+    to.push(consts.SPECIAL_FALSE);
     return;
   }
   switch (typeof data) {
@@ -113,7 +100,7 @@ function encodeImpl(to: number[], data: CalldataEncodable) {
     }
     case "string": {
       const str = new TextEncoder().encode(data);
-      encodeNumWithType(to, BigInt(str.length), TYPE_STR);
+      encodeNumWithType(to, BigInt(str.length), consts.TYPE_STR);
       for (const c of str) {
         to.push(c);
       }
@@ -121,27 +108,24 @@ function encodeImpl(to: number[], data: CalldataEncodable) {
     }
     case "object": {
       if (data instanceof Uint8Array) {
-        encodeNumWithType(to, BigInt(data.length), TYPE_BYTES);
+        encodeNumWithType(to, BigInt(data.length), consts.TYPE_BYTES);
         for (const c of data) {
           to.push(c);
         }
       } else if (data instanceof Array) {
-        encodeNumWithType(to, BigInt(data.length), TYPE_ARR);
+        encodeNumWithType(to, BigInt(data.length), consts.TYPE_ARR);
         for (const c of data) {
           encodeImpl(to, c);
         }
       } else if (data instanceof Map) {
         encodeMap(to, data);
       } else if (data instanceof Address) {
-        to.push(SPECIAL_ADDR);
+        to.push(consts.SPECIAL_ADDR);
         for (const c of data.bytes) {
           to.push(c);
         }
       } else if (Object.getPrototypeOf(data) === Object.prototype) {
-        encodeMap(
-          to,
-          Object.keys(data).map((k): [string, CalldataEncodable] => [k, data[k]]),
-        );
+        encodeMap(to, Object.entries(data));
       } else {
         reportError("unknown object type", data);
       }
@@ -157,6 +141,83 @@ export function encode(data: CalldataEncodable): Uint8Array {
   const arr: number[] = [];
   encodeImpl(arr, data);
   return new Uint8Array(arr);
+}
+
+function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string[]) {
+  to.push("{");
+  for (const [k, v] of data) {
+    to.push(JSON.stringify(k));
+    to.push(":");
+    toStringImpl(v, to);
+  }
+  to.push("}");
+}
+
+function toStringImpl(data: CalldataEncodable, to: string[]) {
+  if (data === null || data === undefined) {
+    to.push("null");
+    return;
+  }
+  if (data === true) {
+    to.push("true");
+    return;
+  }
+  if (data === false) {
+    to.push("false");
+    return;
+  }
+  switch (typeof data) {
+    case "number": {
+      if (!Number.isInteger(data)) {
+        reportError("floats are not supported", data);
+      }
+      to.push(data.toString());
+      return;
+    }
+    case "bigint": {
+      to.push(data.toString());
+      return;
+    }
+    case "string": {
+      to.push(JSON.stringify(data));
+      return;
+    }
+    case "object": {
+      if (data instanceof Uint8Array) {
+        to.push("b#");
+        for (const b of data) {
+          to.push(b.toString(16));
+        }
+      } else if (data instanceof Array) {
+        to.push("[");
+        for (const c of data) {
+          toStringImpl(c, to);
+          to.push(",");
+        }
+        to.push("]");
+      } else if (data instanceof Map) {
+        toStringImplMap(data.entries(), to);
+      } else if (data instanceof Address) {
+        to.push("addr#");
+        for (const c of data.bytes) {
+          to.push(c.toString(16));
+        }
+      } else if (Object.getPrototypeOf(data) === Object.prototype) {
+        toStringImplMap(Object.entries(data), to);
+      } else {
+        reportError("unknown object type", data);
+      }
+      return;
+    }
+    default:
+      reportError("unknown base type", data);
+  }
+}
+
+export function toString(data: CalldataEncodable): string {
+  const to: string[] = [];
+  toStringImpl(data, to);
+  return to.join("");
 }
 
 export function serialize(data: TransactionDataElement[]): `0x${string}` {

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -1,3 +1,4 @@
+import {decode} from "@/abi/calldata/decoder";
 import {encode, serialize, encodeAndSerialize} from "@/abi/calldata/encoder";
 import {Account, ContractSchema, SimulatorChain, GenLayerClient, CalldataEncodable, Address} from "@/types";
 
@@ -39,7 +40,13 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       method: "eth_call",
       params: [requestParams, "latest"],
     });
-    return result;
+
+    if (typeof result === "string") {
+      const val = Uint8Array.from(atob(result), c => c.charCodeAt(0));
+      return decode(val);
+    } else {
+      return "<unknown>";
+    }
   };
 
   client.writeContract = async (args: {


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #40 

# What

<!-- Describe the changes you made. -->

- Added the GenVM decoder to the result obtained from the readContract method

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To allow developers to get the decoded data when calling an Intelligent Contract method

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested in the GenLayer Boilerplate project

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

The same decoder that is currently working in the GenLayer Studio has been added.

# Checks

- [X] I have tested this code
- [X] I have reviewed my own PR
- [X] I have created an issue for this PR
- [X] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

Check that calling a contract read method, now returns a decoded object.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

Read contract data has been decoded so its value can be used
