### PR TITLE
feat: add customtransport to use both wallet and local private keys

### DIFF
--- a/src/accounts/actions.ts
+++ b/src/accounts/actions.ts
@@ -13,16 +13,16 @@ export function accountActions(client: GenLayerClient<SimulatorChain>) {
         params: [address, amount],
       }) as Promise<TransactionHash>;
     },
-    getCurrentNonce: async ({address}: {address: string}): Promise<number> => {
+    getCurrentNonce: async ({address, block = 'latest'}: {address: string, block?: string}): Promise<number> => {
       const addressToUse = address || client.account?.address;
 
       if (!addressToUse) {
         throw new Error("No address provided and no account is connected");
       }
-
+      //@ts-ignore
       return client.request({
         method: "eth_getTransactionCount",
-        params: [addressToUse],
+        params: [addressToUse, block],
       }) as Promise<number>;
     },
   };

--- a/src/accounts/actions.ts
+++ b/src/accounts/actions.ts
@@ -19,7 +19,6 @@ export function accountActions(client: GenLayerClient<SimulatorChain>) {
       if (!addressToUse) {
         throw new Error("No address provided and no account is connected");
       }
-      //@ts-ignore
       return client.request({
         method: "eth_getTransactionCount",
         params: [addressToUse, block],

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -21,12 +21,13 @@ interface ClientConfig {
 export const createClient = (config: ClientConfig = { chain: simulator }) => {
   const chainConfig = config.chain || simulator;
   const rpcUrl = config.endpoint || chainConfig.rpcUrls.default.http[0];
+  const isAddress = typeof config.accountOrAddress !== "object";
 
   const customTransport = {
       async request({method, params}: {method: string; params: any[]}) {
-        if (method.startsWith('eth_') && window.ethereum) {
+        if (method.startsWith('eth_') && isAddress) {
           try {
-            return await window.ethereum.request({method, params});
+            return await window.ethereum?.request({method, params});
           } catch (err) {
             console.warn(`Error using window.ethereum for method ${method}:`, err);
             throw err;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -3,7 +3,7 @@ import {simulator} from "../chains/simulator";
 import {accountActions} from "../accounts/actions";
 import {contractActions, overrideContractActions} from "../contracts/actions";
 import {transactionActions} from "../transactions/actions";
-import {GenLayerClient, SimulatorChain} from "@/types"
+import {GenLayerClient, SimulatorChain} from "@/types";
 
 // Define the configuration interface for the client
 interface ClientConfig {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -15,13 +15,13 @@ interface ClientConfig {
     blockExplorers?: { default: { name: string; url: string } };
   };
   endpoint?: string; // Custom RPC endpoint
-  accountOrAddress?: Account | Address;
+  account?: Account | Address;
 }
 
 export const createClient = (config: ClientConfig = { chain: simulator }) => {
   const chainConfig = config.chain || simulator;
   const rpcUrl = config.endpoint || chainConfig.rpcUrls.default.http[0];
-  const isAddress = typeof config.accountOrAddress !== "object";
+  const isAddress = typeof config.account !== "object";
 
   const customTransport = {
       async request({method, params}: {method: string; params: any[]}) {
@@ -66,7 +66,7 @@ export const createClient = (config: ClientConfig = { chain: simulator }) => {
   const baseClient = createViemClient({
     chain: chainConfig,
     transport: custom(customTransport),
-    ...(config.accountOrAddress ? {account: config.accountOrAddress} : {}),
+    ...(config.account ? {account: config.account} : {}),
   })
     .extend(publicActions)
     .extend(client => accountActions(client as unknown as GenLayerClient<SimulatorChain>))

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,41 +1,78 @@
-import {Account, createClient as createViemClient, http, publicActions} from "viem";
+import {Account, createClient as createViemClient, publicActions, custom, Address} from "viem";
 import {simulator} from "../chains/simulator";
 import {accountActions} from "../accounts/actions";
 import {contractActions, overrideContractActions} from "../contracts/actions";
 import {transactionActions} from "../transactions/actions";
-import {GenLayerClient, SimulatorChain} from "@/types";
+import {GenLayerClient, SimulatorChain} from "@/types"
 
 // Define the configuration interface for the client
 interface ClientConfig {
   chain?: {
     id: number;
     name: string;
-    rpcUrls: {default: {http: readonly string[]}};
-    nativeCurrency: {name: string; symbol: string; decimals: number};
-    blockExplorers?: {default: {name: string; url: string}};
+    rpcUrls: { default: { http: readonly string[] } };
+    nativeCurrency: { name: string; symbol: string; decimals: number };
+    blockExplorers?: { default: { name: string; url: string } };
   };
-  endpoint?: string; // Optional: Custom RPC endpoint override
-  account?: Account;
+  endpoint?: string; // Custom RPC endpoint
+  accountOrAddress?: Account | Address;
 }
 
-// Extend Viem client to work with GenLayer-specific chains (simulator, testnet, etc.)
-export const createClient = (config: ClientConfig = {chain: simulator}) => {
-  // Determine the RPC URL based on the provided configuration or default to the simulator's RPC UR
+export const createClient = (config: ClientConfig = { chain: simulator }) => {
   const chainConfig = config.chain || simulator;
   const rpcUrl = config.endpoint || chainConfig.rpcUrls.default.http[0];
 
-  // Create a Viem client connected to the GenLayer Simulator (or custom chain)
+  const customTransport = {
+      async request({method, params}: {method: string; params: any[]}) {
+        if (method.startsWith('eth_') && window.ethereum) {
+          try {
+            return await window.ethereum.request({method, params});
+          } catch (err) {
+            console.warn(`Error using window.ethereum for method ${method}:`, err);
+            throw err;
+          }
+        } else {
+          try {
+            const response = await fetch(rpcUrl, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: Date.now(),
+                method,
+                params,
+              }),
+            });
+
+            const data = await response.json();
+
+            if (data.error) {
+              throw new Error(data.error.message);
+            }
+
+            return data.result;
+          } catch (err) {
+            console.error(`Error fetching ${method} from GenLayer RPC:`, err);
+            throw err;
+          }
+        }
+      },
+    }
+
+
   const baseClient = createViemClient({
     chain: chainConfig,
-    transport: http(rpcUrl),
-    ...(config.account ? {account: config.account} : {}),
+    transport: custom(customTransport),
+    ...(config.accountOrAddress ? {account: config.accountOrAddress} : {}),
   })
     .extend(publicActions)
     .extend(client => accountActions(client as unknown as GenLayerClient<SimulatorChain>))
     .extend(client => transactionActions(client as unknown as GenLayerClient<SimulatorChain>))
     .extend(client => contractActions(client as unknown as GenLayerClient<SimulatorChain>));
 
-  const genLayerClient = overrideContractActions(baseClient as unknown as GenLayerClient<SimulatorChain>);
+  return overrideContractActions(baseClient as unknown as GenLayerClient<SimulatorChain>);
 
-  return genLayerClient;
 };
+

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -27,20 +27,23 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     functionName: string;
     args: CalldataEncodable[];
   }): Promise<unknown> => {
-    const {account, address, functionName, args: params} = args;
-    const encodedData = encodeAndSerialize({method: functionName, args: params});
+    const { account, address, functionName, args: params } = args;
+    const encodedData = encodeAndSerialize({ method: functionName, args: params });
+
+    let senderAddress = account?.address ?? client.account?.address;
 
     const requestParams = {
       to: address,
-      from: account?.address ?? client.account?.address,
+      from: senderAddress,
       data: encodedData,
     };
-    const result = await client.request({
+
+    return await client.request({
       method: "eth_call",
       params: [requestParams, "latest"],
     });
-    return result;
   };
+
 
   client.writeContract = async (args: {
     account?: Account;
@@ -50,14 +53,30 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     value: bigint;
     leaderOnly?: boolean;
   }): Promise<`0x${string}`> => {
-    const {account, address, functionName, args: params, value = 0n, leaderOnly = false} = args;
-    const data = [encode({method: functionName, args: params}), leaderOnly];
+    const { account, address, functionName, args: params, value = 0n, leaderOnly = false } = args;
+    const data = [encode({ method: functionName, args: params }), leaderOnly];
     const serializedData = serialize(data);
-
     const senderAccount = account || client.account;
+
+
+    if (senderAccount?.type !== "local") {
+
+      const transaction = {
+        from: senderAccount?.address,
+        to: address,
+        data: serializedData,
+        value: `0x${value.toString(16)}`,
+      };
+
+      return await client.request({
+        method: "eth_sendTransaction",
+        params: [transaction as any],
+      });
+    }
+
     if (!senderAccount) {
       throw new Error(
-        "No account set. Configure the client with an account or pass an account to this function.",
+          "No account set. Configure the client with an account or pass an account to this function."
       );
     }
 
@@ -65,7 +84,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       throw new Error("Account does not support signTransaction");
     }
 
-    const nonce = await client.getCurrentNonce({address: senderAccount.address});
+    const nonce = await client.getCurrentNonce({ address: senderAccount.address });
 
     const signedTransaction = await senderAccount.signTransaction({
       data: serializedData,
@@ -74,11 +93,11 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       type: "legacy",
       nonce,
     });
-    const result = await client.request({
+
+    return await client.request({
       method: "eth_sendRawTransaction",
       params: [signedTransaction],
     });
-    return result;
   };
 
   client.deployContract = async (args: {
@@ -87,14 +106,29 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     args: CalldataEncodable[];
     leaderOnly?: boolean;
   }) => {
-    const {account, code, args: constructorArgs, leaderOnly = false} = args;
-    const data = [code, encode({args: constructorArgs}), leaderOnly];
+    const { account, code, args: constructorArgs, leaderOnly = false } = args;
+    const data = [code, encode({ args: constructorArgs }), leaderOnly];
     const serializedData = serialize(data);
-
     const senderAccount = account || client.account;
+
+    if (senderAccount?.type !== "local") {
+
+      const transaction = {
+        from: senderAccount?.address,
+        to: null,
+        data: serializedData,
+        value: "0x0",
+      };
+
+      return  await client.request({
+        method: "eth_sendTransaction",
+        params: [transaction as any],
+      });
+    }
+
     if (!senderAccount) {
       throw new Error(
-        "No account set. Configure the client with an account or pass an account to this function.",
+          "No account set. Configure the client with an account or pass an account to this function."
       );
     }
 
@@ -102,7 +136,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       throw new Error("Account does not support signTransaction");
     }
 
-    const nonce = await client.getCurrentNonce({address: senderAccount.address});
+    const nonce = await client.getCurrentNonce({ address: senderAccount.address });
 
     const signedTransaction = await senderAccount.signTransaction({
       data: serializedData,
@@ -110,11 +144,10 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       nonce,
     });
 
-    const result = await client.request({
+    return  await client.request({
       method: "eth_sendRawTransaction",
       params: [signedTransaction],
     });
-    return result;
   };
 
   return client;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,7 @@
+// global.d.ts
+interface Window {
+  ethereum?: {
+    isMetaMask?: boolean;
+    request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
+  };
+}

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -13,7 +13,7 @@ export type GenLayerMethod =
   | {method: "gen_getContractSchema"; params: [address: string]}
   | {method: "gen_getContractSchemaForCode"; params: [contractCode: string]}
   | {method: "sim_getTransactionsForAddress"; params: [address: string, filter?: "all" | "from" | "to"]}
-  | {method: "eth_getTransactionCount"; params: [address: string]};
+  | {method: "eth_getTransactionCount"; params: [address: string, block: string]};
 
 /*
   Take all the properties from PublicActions<Transport, TSimulatorChain>

--- a/tests/client.test-d.ts
+++ b/tests/client.test-d.ts
@@ -6,7 +6,7 @@ import {TransactionHash, TransactionStatus} from "../src/types/transactions";
 test("type checks", () => {
   const client = createClient({
     chain: simulator,
-    account: createAccount(generatePrivateKey()),
+    accountOrAddress: createAccount(generatePrivateKey()),
   });
 
   const exampleAddress = "0x1234567890123456789012345678901234567890";

--- a/tests/client.test-d.ts
+++ b/tests/client.test-d.ts
@@ -6,7 +6,7 @@ import {TransactionHash, TransactionStatus} from "../src/types/transactions";
 test("type checks", () => {
   const client = createClient({
     chain: simulator,
-    accountOrAddress: createAccount(generatePrivateKey()),
+    account: createAccount(generatePrivateKey()),
   });
 
   const exampleAddress = "0x1234567890123456789012345678901234567890";

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -83,8 +83,6 @@ describe("Client Overrides", () => {
       account,
     });
 
-    const address = '0x65e03a3e916CF1dC92d3C8E8186a89CfAB0D2bc2';
-
     // Mock the client.request method
     vi.spyOn(client, "request").mockResolvedValue(undefined);
 
@@ -100,7 +98,7 @@ describe("Client Overrides", () => {
       params: [
         {
           to: contractAddress,
-          from: address,
+          from: account,
           data: expect.any(String),
         },
         "latest",

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -18,7 +18,7 @@ describe("Client Overrides", () => {
     const account = createAccount(generatePrivateKey());
     const client = createClient({
       chain: simulator,
-      accountOrAddress: account,
+      account: account,
     });
 
     // Mock the client.request method
@@ -45,10 +45,10 @@ describe("Client Overrides", () => {
   });
 
   it("should override client account if account is provided", async () => {
-    const accountOrAddress = createAccount(generatePrivateKey());
+    const account = createAccount(generatePrivateKey());
     const client = createClient({
       chain: simulator,
-      accountOrAddress,
+      account,
     });
 
     const overrideAccount = createAccount(generatePrivateKey());
@@ -77,10 +77,10 @@ describe("Client Overrides", () => {
     });
   });
   it("should override client account if address is provided", async () => {
-    const accountOrAddress = '0x65e03a3e916CF1dC92d3C8E8186a89CfAB0D2bc2';
+    const account = '0x65e03a3e916CF1dC92d3C8E8186a89CfAB0D2bc2';
     const client = createClient({
       chain: simulator,
-      accountOrAddress,
+      account,
     });
 
     const address = '0x65e03a3e916CF1dC92d3C8E8186a89CfAB0D2bc2';

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -18,7 +18,7 @@ describe("Client Overrides", () => {
     const account = createAccount(generatePrivateKey());
     const client = createClient({
       chain: simulator,
-      account,
+      accountOrAddress: account,
     });
 
     // Mock the client.request method
@@ -45,10 +45,10 @@ describe("Client Overrides", () => {
   });
 
   it("should override client account if account is provided", async () => {
-    const account = createAccount(generatePrivateKey());
+    const accountOrAddress = createAccount(generatePrivateKey());
     const client = createClient({
       chain: simulator,
-      account,
+      accountOrAddress,
     });
 
     const overrideAccount = createAccount(generatePrivateKey());
@@ -76,4 +76,36 @@ describe("Client Overrides", () => {
       ],
     });
   });
+  it("should override client account if address is provided", async () => {
+    const accountOrAddress = '0x65e03a3e916CF1dC92d3C8E8186a89CfAB0D2bc2';
+    const client = createClient({
+      chain: simulator,
+      accountOrAddress,
+    });
+
+    const address = '0x65e03a3e916CF1dC92d3C8E8186a89CfAB0D2bc2';
+
+    // Mock the client.request method
+    vi.spyOn(client, "request").mockResolvedValue(undefined);
+
+    const contractAddress = "0x1234567890123456789012345678901234567890";
+    await client.readContract({
+      address: contractAddress as Address,
+      functionName: "testFunction",
+      args: ["arg1", "arg2"],
+    });
+
+    expect(client.request).toHaveBeenCalledWith({
+      method: "eth_call",
+      params: [
+        {
+          to: contractAddress,
+          from: address,
+          data: expect.any(String),
+        },
+        "latest",
+      ],
+    });
+  });
+
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -115,5 +115,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src/**/*", "tests/**/*", "src/global.d.ts"]
 }


### PR DESCRIPTION
Fixes #47

## **Description**
This PR introduces several enhancements and fixes across the GenLayer client, including updated parameter handling for `eth_getTransactionCount`, improved client configuration, and better MetaMask integration. Additionally, it refactors transaction-related logic to ensure compatibility with both local and external accounts.

---

## **Key Changes**

### **1. Accounts (`src/accounts/actions.ts`)**
- Updated the `getCurrentNonce` method to include an optional `block` parameter for compatibility with the latest Ethereum JSON-RPC standards.  
  - **Old**: `params: [address]`  
  - **New**: `params: [address, block]`  
- Ensured proper error handling when no address is provided.

### **2. Client (`src/client/client.ts`)**
#### **Custom Transport for Request Handling**
- A custom transport layer was added to handle requests for `eth_` prefixed methods differently based on the account type, while also supporting non-`eth_` methods like `gen_`.
  
#### **Why was this needed?**
1. **MetaMask Integration**:
   - For `eth_` prefixed methods (e.g., `eth_sendTransaction`, `eth_call`), if the account type is a wallet address (MetaMask), the request is routed through `window.ethereum.request`. This ensures MetaMask is correctly used for signing and managing transactions.
2. **Local Account Handling**:
   - When working with local accounts (or when MetaMask is unavailable), requests need to bypass MetaMask and be sent directly to the configured RPC endpoint using `fetch`. This applies to both `eth_` methods and custom methods.
3. **Non-Ethereum Standard Methods (`gen_`)**:
   - Custom methods like `gen_` (specific to GenLayer) require direct handling via the RPC endpoint, as they are not part of the Ethereum standard and cannot be processed by MetaMask.

#### **How does it work?**
The custom transport dynamically determines the handling logic based on the request:
- **`if` Block (MetaMask)**:
  - Routes `eth_` prefixed methods to `window.ethereum.request` if the account is a wallet address.
  - Example:
    ```typescript
    if (method.startsWith('eth_') && isAddress) {
      return await window.ethereum?.request({method, params});
    }
    ```
- **`else` Block (Local Accounts & Non-`eth_` Methods)**:
  - For local accounts or custom methods (`gen_`), it sends requests directly to the RPC endpoint.
  - This ensures:
    - Custom methods like `gen_getContractSchema` are handled properly.
    - Local accounts (with signing support) can process transactions without relying on MetaMask.
  - Example:
    ```typescript
    const response = await fetch(rpcUrl, {
      method: 'POST',
      headers: { 'Content-Type': 'application/json' },
      body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method, params }),
    });
    ```

---

### **3. Contracts (`src/contracts/actions.ts`)**
- Refactored transaction creation logic:
  - Differentiated between local accounts and external accounts like MetaMask.
  - Ensured transactions are properly signed depending on the account type.
- Added better handling for `eth_sendTransaction` and `eth_sendRawTransaction`.

### **4. Global Types (`src/global.d.ts`)**
- Declared a `window.ethereum` interface to enable MetaMask support in TypeScript.

### **5. Type Updates (`src/types/clients.ts`)**
- Updated the `eth_getTransactionCount` type to include the `block` parameter for improved flexibility.

### **6. Test Enhancements**
- Refactored tests in `tests/client.test.ts` to validate the `accountOrAddress` feature.
- Added new test cases to ensure the client properly overrides account behavior when `address` is provided.

### **7. Config Updates (`tsconfig.json`)**
- Included `src/global.d.ts` to allow TypeScript to recognize the `window.ethereum` interface globally.

---

## **Testing**

### **Steps**
1. **Set up MetaMask**:
   - Connect MetaMask and use the Studio frontend to test switching between local and MetaMask accounts.
2. **Run Unit Tests**:
   - Execute `npm test` to verify the changes.
3. **Test Transactions**:
   - Create and sign transactions with both local and MetaMask accounts.
   - Test switching accounts and ensure the correct account is used.

