### PR TITLE
feat: add stateStatus in readContract

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ const result = await client.readContract({
   address: contractAddress,
   functionName: 'get_complete_storage',
   args: []
+  stateStatus: "accepted",
 })
 ```
 

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -1,5 +1,5 @@
 import {decode} from "@/abi/calldata/decoder";
-import {encode, serialize, encodeAndSerialize} from "@/abi/calldata/encoder";
+import {encode, serialize} from "@/abi/calldata/encoder";
 import {Account, ContractSchema, SimulatorChain, GenLayerClient, CalldataEncodable, Address} from "@/types";
 
 export const contractActions = (client: GenLayerClient<SimulatorChain>) => {

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -1,6 +1,14 @@
 import {decode} from "@/abi/calldata/decoder";
 import {encode, serialize} from "@/abi/calldata/encoder";
-import {Account, ContractSchema, SimulatorChain, GenLayerClient, CalldataEncodable, Address} from "@/types";
+import {
+  Account,
+  ContractSchema,
+  SimulatorChain,
+  GenLayerClient,
+  CalldataEncodable,
+  Address,
+  TransactionStatus,
+} from "@/types";
 
 export const contractActions = (client: GenLayerClient<SimulatorChain>) => {
   return {
@@ -27,14 +35,14 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     address: Address;
     functionName: string;
     args: CalldataEncodable[];
-    stateStatus: string;
+    stateStatus?: TransactionStatus;
   }): Promise<unknown> => {
-    const {account, address, functionName, args: params, stateStatus} = args;
+    const {account, address, functionName, args: params, stateStatus = TransactionStatus.ACCEPTED} = args;
     const encodedData = [encode({method: functionName, args: params}), stateStatus];
     const serializedData = serialize(encodedData);
 
     const senderAddress = account?.address ?? client.account?.address;
-    
+
     const requestParams = {
       to: address,
       from: senderAddress,
@@ -53,7 +61,6 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     }
   };
 
-
   client.writeContract = async (args: {
     account?: Account;
     address: Address;
@@ -62,14 +69,12 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     value: bigint;
     leaderOnly?: boolean;
   }): Promise<`0x${string}`> => {
-    const { account, address, functionName, args: params, value = 0n, leaderOnly = false } = args;
-    const data = [encode({ method: functionName, args: params }), leaderOnly];
+    const {account, address, functionName, args: params, value = 0n, leaderOnly = false} = args;
+    const data = [encode({method: functionName, args: params}), leaderOnly];
     const serializedData = serialize(data);
     const senderAccount = account || client.account;
 
-
     if (senderAccount?.type !== "local") {
-
       const transaction = {
         from: senderAccount?.address,
         to: address,
@@ -85,7 +90,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
 
     if (!senderAccount) {
       throw new Error(
-          "No account set. Configure the client with an account or pass an account to this function."
+        "No account set. Configure the client with an account or pass an account to this function.",
       );
     }
 
@@ -93,7 +98,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       throw new Error("Account does not support signTransaction");
     }
 
-    const nonce = await client.getCurrentNonce({ address: senderAccount.address });
+    const nonce = await client.getCurrentNonce({address: senderAccount.address});
 
     const signedTransaction = await senderAccount.signTransaction({
       data: serializedData,
@@ -115,13 +120,12 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     args: CalldataEncodable[];
     leaderOnly?: boolean;
   }) => {
-    const { account, code, args: constructorArgs, leaderOnly = false } = args;
-    const data = [code, encode({ args: constructorArgs }), leaderOnly];
+    const {account, code, args: constructorArgs, leaderOnly = false} = args;
+    const data = [code, encode({args: constructorArgs}), leaderOnly];
     const serializedData = serialize(data);
     const senderAccount = account || client.account;
 
     if (senderAccount?.type !== "local") {
-
       const transaction = {
         from: senderAccount?.address,
         to: null,
@@ -129,7 +133,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
         value: "0x0",
       };
 
-      return  await client.request({
+      return await client.request({
         method: "eth_sendTransaction",
         params: [transaction as any],
       });
@@ -137,7 +141,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
 
     if (!senderAccount) {
       throw new Error(
-          "No account set. Configure the client with an account or pass an account to this function."
+        "No account set. Configure the client with an account or pass an account to this function.",
       );
     }
 
@@ -145,7 +149,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       throw new Error("Account does not support signTransaction");
     }
 
-    const nonce = await client.getCurrentNonce({ address: senderAccount.address });
+    const nonce = await client.getCurrentNonce({address: senderAccount.address});
 
     const signedTransaction = await senderAccount.signTransaction({
       data: serializedData,
@@ -153,7 +157,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       nonce,
     });
 
-    return  await client.request({
+    return await client.request({
       method: "eth_sendRawTransaction",
       params: [signedTransaction],
     });

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -27,14 +27,16 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     address: Address;
     functionName: string;
     args: CalldataEncodable[];
+    stateStatus: string;
   }): Promise<unknown> => {
-    const {account, address, functionName, args: params} = args;
-    const encodedData = encodeAndSerialize({method: functionName, args: params});
+    const {account, address, functionName, args: params, stateStatus} = args;
+    const encodedData = [encode({method: functionName, args: params}), stateStatus];
+    const serializedData = serialize(encodedData);
 
     const requestParams = {
       to: address,
       from: account?.address ?? client.account?.address,
-      data: encodedData,
+      data: serializedData,
     };
     const result = await client.request({
       method: "eth_call",

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -39,7 +39,7 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
       address: Address;
       functionName: string;
       args: CalldataEncodable[];
-      stateStatus: string;
+      stateStatus?: TransactionStatus;
     }) => Promise<unknown>;
     writeContract: (args: {
       account?: Account;

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -39,6 +39,7 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
       address: Address;
       functionName: string;
       args: CalldataEncodable[];
+      stateStatus: string;
     }) => Promise<unknown>;
     writeContract: (args: {
       account?: Account;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -29,6 +29,7 @@ describe("Client Overrides", () => {
       address: contractAddress as Address,
       functionName: "testFunction",
       args: ["arg1", "arg2"],
+      stateStatus: "accepted",
     });
 
     expect(client.request).toHaveBeenCalledWith({
@@ -62,6 +63,7 @@ describe("Client Overrides", () => {
       address: contractAddress as Address,
       functionName: "testFunction",
       args: ["arg1", "arg2"],
+      stateStatus: "accepted",
     });
 
     expect(client.request).toHaveBeenCalledWith({

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -4,6 +4,7 @@ import {simulator} from "../src/chains/simulator";
 import {Address} from "../src/types/accounts";
 import {createAccount, generatePrivateKey} from "../src/accounts/account";
 import {vi} from "vitest";
+import {TransactionStatus} from "../src/types/transactions";
 
 describe("Client Creation", () => {
   it("should create a client for the simulator", () => {
@@ -29,7 +30,7 @@ describe("Client Overrides", () => {
       address: contractAddress as Address,
       functionName: "testFunction",
       args: ["arg1", "arg2"],
-      stateStatus: "accepted",
+      stateStatus: TransactionStatus.ACCEPTED,
     });
 
     expect(client.request).toHaveBeenCalledWith({
@@ -63,7 +64,7 @@ describe("Client Overrides", () => {
       address: contractAddress as Address,
       functionName: "testFunction",
       args: ["arg1", "arg2"],
-      stateStatus: "accepted",
+      stateStatus: TransactionStatus.ACCEPTED,
     });
 
     expect(client.request).toHaveBeenCalledWith({
@@ -79,7 +80,7 @@ describe("Client Overrides", () => {
     });
   });
   it("should override client account if address is provided", async () => {
-    const account = '0x65e03a3e916CF1dC92d3C8E8186a89CfAB0D2bc2';
+    const account = "0x65e03a3e916CF1dC92d3C8E8186a89CfAB0D2bc2";
     const client = createClient({
       chain: simulator,
       account,
@@ -107,5 +108,4 @@ describe("Client Overrides", () => {
       ],
     });
   });
-
 });


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes partly https://github.com/yeagerai/genlayer-studio/issues/788

# What

<!-- Describe the changes you made. -->

- Added stateStatus argument to readContract of the client. This is passed to the eth_call.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To add more value to the user

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the new feature in the studio

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
Check code changes.

# Depends on
Studio PR

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
ReadContract contains stateStatus argument to read the accepted or the finalized contract state.