### PR TITLE
fix: refactor abi to prevent confusion

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,7 +39,7 @@ module.exports = {
         "no-fallthrough": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-floating-promises": ["error"],
-        "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+        "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
       },
     },
   ],

--- a/src/abi/calldata/decoder.ts
+++ b/src/abi/calldata/decoder.ts
@@ -1,5 +1,5 @@
 import type {CalldataEncodable} from "../../types/calldata";
-import {Address} from "../../types/calldata";
+import {CalldataAddress} from "../../types/calldata";
 import * as consts from "./consts";
 
 function readULeb128(data: Uint8Array, index: {i: number}): bigint {
@@ -29,7 +29,7 @@ function decodeImpl(data: Uint8Array, index: {i: number}): CalldataEncodable {
     case BigInt(consts.SPECIAL_ADDR): {
       const res = data.slice(index.i, index.i + 20);
       index.i += 20;
-      return new Address(res);
+      return new CalldataAddress(res);
     }
   }
   const type = Number(cur & 0xffn) & ((1 << consts.BITS_IN_TYPE) - 1);

--- a/src/abi/calldata/encoder.ts
+++ b/src/abi/calldata/encoder.ts
@@ -1,7 +1,5 @@
-import {toHex} from "viem";
-import {toRlp} from "viem";
-import type {CalldataEncodable, TransactionDataElement} from "../../types/calldata";
-import {Address} from "../../types/calldata";
+import type {CalldataEncodable} from "../../types/calldata";
+import {CalldataAddress} from "../../types/calldata";
 import * as consts from "./consts";
 
 function reportError(msg: string, data: CalldataEncodable): never {
@@ -119,7 +117,7 @@ function encodeImpl(to: number[], data: CalldataEncodable) {
         }
       } else if (data instanceof Map) {
         encodeMap(to, data);
-      } else if (data instanceof Address) {
+      } else if (data instanceof CalldataAddress) {
         to.push(consts.SPECIAL_ADDR);
         for (const c of data.bytes) {
           to.push(c);
@@ -141,89 +139,4 @@ export function encode(data: CalldataEncodable): Uint8Array {
   const arr: number[] = [];
   encodeImpl(arr, data);
   return new Uint8Array(arr);
-}
-
-function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string[]) {
-  to.push("{");
-  for (const [k, v] of data) {
-    to.push(JSON.stringify(k));
-    to.push(":");
-    toStringImpl(v, to);
-  }
-  to.push("}");
-}
-
-function toStringImpl(data: CalldataEncodable, to: string[]) {
-  if (data === null || data === undefined) {
-    to.push("null");
-    return;
-  }
-  if (data === true) {
-    to.push("true");
-    return;
-  }
-  if (data === false) {
-    to.push("false");
-    return;
-  }
-  switch (typeof data) {
-    case "number": {
-      if (!Number.isInteger(data)) {
-        reportError("floats are not supported", data);
-      }
-      to.push(data.toString());
-      return;
-    }
-    case "bigint": {
-      to.push(data.toString());
-      return;
-    }
-    case "string": {
-      to.push(JSON.stringify(data));
-      return;
-    }
-    case "object": {
-      if (data instanceof Uint8Array) {
-        to.push("b#");
-        for (const b of data) {
-          to.push(b.toString(16));
-        }
-      } else if (data instanceof Array) {
-        to.push("[");
-        for (const c of data) {
-          toStringImpl(c, to);
-          to.push(",");
-        }
-        to.push("]");
-      } else if (data instanceof Map) {
-        toStringImplMap(data.entries(), to);
-      } else if (data instanceof Address) {
-        to.push("addr#");
-        for (const c of data.bytes) {
-          to.push(c.toString(16));
-        }
-      } else if (Object.getPrototypeOf(data) === Object.prototype) {
-        toStringImplMap(Object.entries(data), to);
-      } else {
-        reportError("unknown object type", data);
-      }
-      return;
-    }
-    default:
-      reportError("unknown base type", data);
-  }
-}
-
-export function toString(data: CalldataEncodable): string {
-  const to: string[] = [];
-  toStringImpl(data, to);
-  return to.join("");
-}
-
-export function serialize(data: TransactionDataElement[]): `0x${string}` {
-  return toRlp(data.map(param => toHex(param)));
-}
-
-export function encodeAndSerialize(data: CalldataEncodable): `0x${string}` {
-  return serialize([encode(data)]);
 }

--- a/src/abi/calldata/index.ts
+++ b/src/abi/calldata/index.ts
@@ -1,0 +1,3 @@
+export * from "./encoder";
+export * from "./decoder";
+export * from "./string";

--- a/src/abi/calldata/string.ts
+++ b/src/abi/calldata/string.ts
@@ -1,0 +1,83 @@
+import type {CalldataEncodable} from "../../types/calldata";
+import {CalldataAddress} from "../../types/calldata";
+
+function reportError(msg: string, data: CalldataEncodable): never {
+    throw new Error(`invalid calldata input '${data}'`);
+}
+
+function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string[]) {
+    to.push("{");
+    for (const [k, v] of data) {
+      to.push(JSON.stringify(k));
+      to.push(":");
+      toStringImpl(v, to);
+    }
+    to.push("}");
+  }
+
+  function toStringImpl(data: CalldataEncodable, to: string[]) {
+    if (data === null || data === undefined) {
+      to.push("null");
+      return;
+    }
+    if (data === true) {
+      to.push("true");
+      return;
+    }
+    if (data === false) {
+      to.push("false");
+      return;
+    }
+    switch (typeof data) {
+      case "number": {
+        if (!Number.isInteger(data)) {
+          reportError("floats are not supported", data);
+        }
+        to.push(data.toString());
+        return;
+      }
+      case "bigint": {
+        to.push(data.toString());
+        return;
+      }
+      case "string": {
+        to.push(JSON.stringify(data));
+        return;
+      }
+      case "object": {
+        if (data instanceof Uint8Array) {
+          to.push("b#");
+          for (const b of data) {
+            to.push(b.toString(16));
+          }
+        } else if (data instanceof Array) {
+          to.push("[");
+          for (const c of data) {
+            toStringImpl(c, to);
+            to.push(",");
+          }
+          to.push("]");
+        } else if (data instanceof Map) {
+          toStringImplMap(data.entries(), to);
+        } else if (data instanceof CalldataAddress) {
+          to.push("addr#");
+          for (const c of data.bytes) {
+            to.push(c.toString(16));
+          }
+        } else if (Object.getPrototypeOf(data) === Object.prototype) {
+          toStringImplMap(Object.entries(data), to);
+        } else {
+          reportError("unknown object type", data);
+        }
+        return;
+      }
+      default:
+        reportError("unknown base type", data);
+    }
+  }
+
+  export function toString(data: CalldataEncodable): string {
+    const to: string[] = [];
+    toStringImpl(data, to);
+    return to.join("");
+  }

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -1,1 +1,5 @@
-export * from "./calldata/encoder";
+import * as cd from "./calldata"
+import * as tx from "./transactions"
+
+export const calldata = cd;
+export const transactions = tx;

--- a/src/abi/transactions.ts
+++ b/src/abi/transactions.ts
@@ -1,0 +1,11 @@
+import {toHex, toRlp} from "viem";
+
+import type {TransactionDataElement} from "../types/calldata";
+
+export function serializeOne(data: TransactionDataElement): `0x${string}` {
+    return toHex(data)
+}
+
+export function serialize(data: TransactionDataElement[]): `0x${string}` {
+    return toRlp(data.map(serializeOne));
+}

--- a/src/contracts/IContractActions.ts
+++ b/src/contracts/IContractActions.ts
@@ -1,8 +1,0 @@
-import {ContractSchema} from "@/types";
-import {Address} from "viem";
-
-export type IContractActions = {
-  getContractSchema: (code: string) => Promise<ContractSchema>;
-  getContractSchemaForCode: (address: string) => Promise<ContractSchema>;
-  readContract: (args: {address: Address; functionName: string; args: any[]}) => Promise<unknown>;
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@
 export {createClient} from "./client/client";
 export {createAccount, generatePrivateKey} from "./accounts/account";
 export * as chains from "./chains";
+export * as abi from "./abi";

--- a/src/types/calldata.ts
+++ b/src/types/calldata.ts
@@ -1,8 +1,8 @@
-export class Address {
+export class CalldataAddress {
   bytes: Uint8Array;
 
   constructor(addr: Uint8Array) {
-    if (addr.length != 32) {
+    if (addr.length != 20) {
       throw new Error(`invalid address length ${addr}`);
     }
 
@@ -13,7 +13,7 @@ export class Address {
 export type CalldataEncodable =
   | null
   | boolean
-  | Address
+  | CalldataAddress
   | number
   | bigint
   | string
@@ -26,12 +26,6 @@ export type MethodDescription = {
   method: string;
 
   args: Array<CalldataEncodable>;
-};
-
-export type TransactionData = {
-  method: string;
-
-  args: CalldataEncodable[];
 };
 
 export type TransactionDataElement = string | number | bigint | boolean | Uint8Array;

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -9,7 +9,7 @@ export type GenLayerMethod =
   | {method: "sim_fundAccount"; params: [address: string, amount: number]}
   | {method: "eth_getTransactionByHash"; params: [hash: TransactionHash]}
   | {method: "eth_call"; params: [requestParams: any, blockNumberOrHash: string]}
-  | {method: "eth_sedRawTransaction"; params: [signedTransaction: string]}
+  | {method: "eth_sendRawTransaction"; params: [signedTransaction: string]}
   | {method: "gen_getContractSchema"; params: [address: string]}
   | {method: "gen_getContractSchemaForCode"; params: [contractCode: string]}
   | {method: "sim_getTransactionsForAddress"; params: [address: string, filter?: "all" | "from" | "to"]}
@@ -34,25 +34,29 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
         args: Extract<GenLayerMethod, {method: TMethod["method"]}>,
       ): Promise<unknown>;
     };
-    readContract: (args: {
+    readContract: <RawReturn extends boolean | undefined>(args: {
       account?: Account;
       address: Address;
       functionName: string;
-      args: CalldataEncodable[];
       stateStatus?: TransactionStatus;
-    }) => Promise<unknown>;
+      args?: CalldataEncodable[];
+      kwargs?: Map<string, CalldataEncodable> | { [key: string]: CalldataEncodable };
+      rawReturn?: RawReturn;
+    }) => Promise<RawReturn extends true ? `0x${string}` : CalldataEncodable>;
     writeContract: (args: {
       account?: Account;
       address: Address;
       functionName: string;
-      args: CalldataEncodable[];
+      args?: CalldataEncodable[];
+      kwargs?: Map<string, CalldataEncodable> | { [key: string]: CalldataEncodable };
       value: bigint;
       leaderOnly?: boolean;
     }) => Promise<any>;
     deployContract: (args: {
       account?: Account;
-      code: string;
-      args: CalldataEncodable[];
+      code: string | Uint8Array;
+      args?: CalldataEncodable[];
+      kwargs?: Map<string, CalldataEncodable> | { [key: string]: CalldataEncodable };
       leaderOnly?: boolean;
     }) => Promise<`0x${string}`>;
     getTransaction: (args: {hash: TransactionHash}) => Promise<GenLayerTransaction>;
@@ -64,5 +68,5 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
       retries?: number;
     }) => Promise<GenLayerTransaction>;
     getContractSchema: (address: string) => Promise<ContractSchema>;
-    getContractSchemaForCode: (contractCode: string) => Promise<ContractSchema>;
+    getContractSchemaForCode: (contractCode: string | Uint8Array) => Promise<ContractSchema>;
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 export * from "./accounts";
-export {CalldataEncodable, MethodDescription, TransactionData} from "./calldata";
+export {CalldataEncodable, MethodDescription, CalldataAddress} from "./calldata";
 export * from "./chains";
 export * from "./clients";
 export * from "./contracts";

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -23,7 +23,7 @@ describe("Client Overrides", () => {
     });
 
     // Mock the client.request method
-    vi.spyOn(client, "request").mockResolvedValue(undefined);
+    vi.spyOn(client, "request").mockResolvedValue("0x00");
 
     const contractAddress = "0x1234567890123456789012345678901234567890";
     await client.readContract({
@@ -56,7 +56,7 @@ describe("Client Overrides", () => {
     const overrideAccount = createAccount(generatePrivateKey());
 
     // Mock the client.request method
-    vi.spyOn(client, "request").mockResolvedValue(undefined);
+    vi.spyOn(client, "request").mockResolvedValue("0x00");
 
     const contractAddress = "0x1234567890123456789012345678901234567890";
     await client.readContract({
@@ -87,7 +87,7 @@ describe("Client Overrides", () => {
     });
 
     // Mock the client.request method
-    vi.spyOn(client, "request").mockResolvedValue(undefined);
+    vi.spyOn(client, "request").mockResolvedValue("0x00");
 
     const contractAddress = "0x1234567890123456789012345678901234567890";
     await client.readContract({


### PR DESCRIPTION
Fixes #49 #52

Linked PR: https://github.com/yeagerai/genlayer-studio/pull/805

# What: code is not a string
Code is not a string, it can be wasm file for instance. For that reason I am changing type in `deploy contract`, rlp works the same for byte arrays and utf8 strings, so there is no problem with that

# What: abi

There is a confusion in abi. We have different entities:
1. calldata (for genvm)
2. rlp (for eth_call and friends)

For this reason I think we shouldn't mix them. GenVM inside doesn't use rlp for any communication

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- to expose more functionality
- to prevent further user confusion

# Testing done

none

# Decisions made

As of get schema for code, I am unsure about which encoding to use, so I choose toHex as in other simulator methods.

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
