### PR TITLE
fix: override chain endpoint if extra config provided

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -21,7 +21,9 @@ interface ClientConfig {
 
 export const createClient = (config: ClientConfig = {chain: simulator}) => {
   const chainConfig = config.chain || simulator;
-  const rpcUrl = config.endpoint || chainConfig.rpcUrls.default.http[0];
+  if (config.endpoint) {
+    chainConfig.rpcUrls.default.http = [config.endpoint];
+  }
   const isAddress = typeof config.account !== "object";
 
   const customTransport = {
@@ -35,7 +37,7 @@ export const createClient = (config: ClientConfig = {chain: simulator}) => {
         }
       } else {
         try {
-          const response = await fetch(rpcUrl, {
+          const response = await fetch(chainConfig.rpcUrls.default.http[0], {
             method: "POST",
             headers: {
               "Content-Type": "application/json",


### PR DESCRIPTION
# What

- Modified RPC endpoint handling to update the chain config's RPC URLs array instead of using a separate variable
- Updated fetch call to use the first URL from the chain config's RPC URLs array

# Why

- Maintains consistency by keeping all RPC URL configuration within the chain config object
- Ensures the chain config always reflects the current RPC endpoint being used

# Testing done

- Verified client initialization with both default and custom endpoints
- Tested RPC requests work correctly with modified URL handling

# Decisions made

- Chose to modify the chain config directly rather than maintaining a separate RPC URL variable
- Kept the first URL in the array as the primary endpoint for RPC calls

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with conventional commits

# User facing release notes

This change improves how RPC endpoints are handled in the client configuration, maintaining better consistency in how endpoints are stored and accessed. This is an internal refactor with no user-visible changes to functionality.