### PR TITLE
feat: add gen_call to readContract

### DIFF
--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -9,6 +9,7 @@ import {
   Address
 } from "@/types";
 import {fromHex, toHex, zeroAddress, encodeFunctionData} from "viem";
+import {BlockIdParam} from "@/types/transactions";
 
 function makeCalldataObject(
   method: string | undefined,
@@ -73,7 +74,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     functionName: string;
     args?: CalldataEncodable[];
     kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
-    blockId?: string;
+    blockId?: BlockIdParam;
     leaderResults?: {[key: string]: `0x${string}`};
     rawReturn?: RawReturn;
   }): Promise<RawReturn extends true ? `0x${string}` : CalldataEncodable> => {

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -104,10 +104,11 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     });
 
     if (args.rawReturn) {
-      return result;
+      return result as RawReturn extends true ? `0x${string}` : CalldataEncodable;
     }
-    const resultBinary = fromHex(result, "bytes");
-    return calldata.decode(resultBinary) as any;
+
+    const resultBinary = fromHex(result as `0x${string}`, "bytes");
+    return calldata.decode(resultBinary) as RawReturn extends true ? `0x${string}` : CalldataEncodable;
   };
 
   client.writeContract = async (args: {

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -97,7 +97,10 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       data: serializedData,
       block_id: blockId,
       leader_results: leaderResults,
+      // ...(blockId && { block_id: blockId }),
+      // ...(leaderResults && { leader_results: leaderResults }),
     };
+    
     const result = await client.request({
       method: "gen_call",
       params: [requestParams],

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -88,7 +88,6 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     } = args;
     const encodedData = calldata.encode(makeCalldataObject(functionName, callArgs, kwargs));
     const serializedData = serializeOne(encodedData);
-    console.log("blockId", blockId);
 
     const senderAddress = account?.address ?? client.account?.address;
 

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -74,6 +74,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     args?: CalldataEncodable[];
     kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
     blockId?: string;
+    leaderResults?: {[key: string]: `0x${string}`};
     rawReturn?: RawReturn;
   }): Promise<RawReturn extends true ? `0x${string}` : CalldataEncodable> => {
     const {
@@ -83,6 +84,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       args: callArgs,
       kwargs,
       blockId,
+      leaderResults,
     } = args;
     const encodedData = calldata.encode(makeCalldataObject(functionName, callArgs, kwargs));
     const serializedData = serializeOne(encodedData);
@@ -94,6 +96,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       from: senderAddress,
       data: serializedData,
       blockId: blockId,
+      leaderResults: leaderResults,
     };
     const result = await client.request({
       method: "gen_call",

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -6,8 +6,7 @@ import {
   SimulatorChain,
   GenLayerClient,
   CalldataEncodable,
-  Address,
-  TransactionStatus,
+  Address
 } from "@/types";
 import {fromHex, toHex, zeroAddress, encodeFunctionData} from "viem";
 
@@ -74,7 +73,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     functionName: string;
     args?: CalldataEncodable[];
     kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
-    stateStatus?: TransactionStatus;
+    blockId?: string;
     rawReturn?: RawReturn;
   }): Promise<RawReturn extends true ? `0x${string}` : CalldataEncodable> => {
     const {
@@ -83,7 +82,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       functionName,
       args: callArgs,
       kwargs,
-      stateStatus = TransactionStatus.ACCEPTED,
+      blockId,
     } = args;
     const encodedData = calldata.encode(makeCalldataObject(functionName, callArgs, kwargs));
     const serializedData = serializeOne(encodedData);
@@ -94,10 +93,11 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       to: address,
       from: senderAddress,
       data: serializedData,
+      blockId: blockId,
     };
     const result = await client.request({
-      method: "eth_call",
-      params: [requestParams, stateStatus == TransactionStatus.FINALIZED ? "finalized" : "latest"],
+      method: "gen_call",
+      params: [requestParams],
     });
 
     if (args.rawReturn) {

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -97,8 +97,6 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       data: serializedData,
       block_id: blockId,
       leader_results: leaderResults,
-      // ...(blockId && { block_id: blockId }),
-      // ...(leaderResults && { leader_results: leaderResults }),
     };
     
     const result = await client.request({

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -88,6 +88,7 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
     } = args;
     const encodedData = calldata.encode(makeCalldataObject(functionName, callArgs, kwargs));
     const serializedData = serializeOne(encodedData);
+    console.log("blockId", blockId);
 
     const senderAddress = account?.address ?? client.account?.address;
 
@@ -95,8 +96,8 @@ export const overrideContractActions = (client: GenLayerClient<SimulatorChain>) 
       to: address,
       from: senderAddress,
       data: serializedData,
-      blockId: blockId,
-      leaderResults: leaderResults,
+      block_id: blockId,
+      leader_results: leaderResults,
     };
     const result = await client.request({
       method: "gen_call",

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -4,6 +4,7 @@ import {SimulatorChain} from "./chains";
 import {Address, Account} from "./accounts";
 import {CalldataEncodable} from "./calldata";
 import {ContractSchema} from "./contracts";
+import {BlockIdParam} from "@/types/transactions";
 
 export type GenLayerMethod =
   | {method: "sim_fundAccount"; params: [address: string, amount: number]}
@@ -40,7 +41,7 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
       account?: Account;
       address: Address;
       functionName: string;
-      blockId?: string;
+      blockId?: BlockIdParam;
       leaderResults?: {[key: string]: `0x${string}`};
       args?: CalldataEncodable[];
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -41,6 +41,7 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
       address: Address;
       functionName: string;
       blockId?: string;
+      leaderResults?: {[key: string]: `0x${string}`};
       args?: CalldataEncodable[];
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
       rawReturn?: RawReturn;

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -9,6 +9,7 @@ export type GenLayerMethod =
   | {method: "sim_fundAccount"; params: [address: string, amount: number]}
   | {method: "eth_getTransactionByHash"; params: [hash: TransactionHash]}
   | {method: "eth_call"; params: [requestParams: any, blockNumberOrHash: string]}
+  | {method: "gen_call"; params: [requestParams: any]}
   | {method: "eth_sendRawTransaction"; params: [signedTransaction: string]}
   | {method: "gen_getContractSchema"; params: [address: string]}
   | {method: "gen_getContractSchemaForCode"; params: [contractCode: string]}
@@ -39,7 +40,7 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
       account?: Account;
       address: Address;
       functionName: string;
-      stateStatus?: TransactionStatus;
+      blockId?: string;
       args?: CalldataEncodable[];
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
       rawReturn?: RawReturn;

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -46,3 +46,17 @@ export type GenLayerTransaction = {
 };
 
 export type TransactionDataElement = string | number | bigint | boolean | Uint8Array;
+
+export enum BlockId {
+  LATEST_FINAL = "latest-final",
+  LATEST_NONFINAL = "latest-nonfinal"
+}
+
+export type ArchiveBlockId = `archive:${string}`;
+
+export type BlockIdParam = BlockId | ArchiveBlockId;
+
+export function createArchiveBlockId(identifier: string | number): ArchiveBlockId {
+  return `archive:${identifier}` as ArchiveBlockId;
+}
+

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -64,6 +64,7 @@ describe("Client Overrides", () => {
       functionName: "testFunction",
       args: ["arg1", "arg2"],
       blockId: "latest-final",
+      leaderResults: {"0": "0x0123456789012345678901234567890123456789"},
     });
 
     expect(client.request).toHaveBeenCalledWith({
@@ -74,6 +75,7 @@ describe("Client Overrides", () => {
           from: overrideAccount.address,
           data: expect.any(String),
           block_id: "latest-final",
+          leader_results: {"0": "0x0123456789012345678901234567890123456789"},
         },
       ],
     });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -4,7 +4,6 @@ import {simulator} from "../src/chains/simulator";
 import {Address} from "../src/types/accounts";
 import {createAccount, generatePrivateKey} from "../src/accounts/account";
 import {vi} from "vitest";
-import {TransactionStatus} from "../src/types/transactions";
 
 describe("Client Creation", () => {
   it("should create a client for the simulator", () => {
@@ -30,18 +29,18 @@ describe("Client Overrides", () => {
       address: contractAddress as Address,
       functionName: "testFunction",
       args: ["arg1", "arg2"],
-      stateStatus: TransactionStatus.ACCEPTED,
+      blockId: "latest-nonfinal",
     });
 
     expect(client.request).toHaveBeenCalledWith({
-      method: "eth_call",
+      method: "gen_call",
       params: [
         {
           to: contractAddress,
           from: account.address,
           data: expect.any(String),
+          block_id: "latest-nonfinal",
         },
-        "latest",
       ],
     });
   });
@@ -64,18 +63,18 @@ describe("Client Overrides", () => {
       address: contractAddress as Address,
       functionName: "testFunction",
       args: ["arg1", "arg2"],
-      stateStatus: TransactionStatus.ACCEPTED,
+      blockId: "latest-final",
     });
 
     expect(client.request).toHaveBeenCalledWith({
-      method: "eth_call",
+      method: "gen_call",
       params: [
         {
           to: contractAddress,
           from: overrideAccount.address,
           data: expect.any(String),
+          block_id: "latest-final",
         },
-        "latest",
       ],
     });
   });
@@ -97,14 +96,13 @@ describe("Client Overrides", () => {
     });
 
     expect(client.request).toHaveBeenCalledWith({
-      method: "eth_call",
+      method: "gen_call",
       params: [
         {
           to: contractAddress,
           from: account,
           data: expect.any(String),
         },
-        "latest",
       ],
     });
   });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -4,7 +4,7 @@ import {simulator} from "../src/chains/simulator";
 import {Address} from "../src/types/accounts";
 import {createAccount, generatePrivateKey} from "../src/accounts/account";
 import {vi} from "vitest";
-
+import {BlockId, createArchiveBlockId} from "../src/types/transactions";
 describe("Client Creation", () => {
   it("should create a client for the simulator", () => {
     const client = createClient({chain: simulator});
@@ -29,7 +29,7 @@ describe("Client Overrides", () => {
       address: contractAddress as Address,
       functionName: "testFunction",
       args: ["arg1", "arg2"],
-      blockId: "latest-nonfinal",
+      blockId: BlockId.LATEST_FINAL,
     });
 
     expect(client.request).toHaveBeenCalledWith({
@@ -39,7 +39,7 @@ describe("Client Overrides", () => {
           to: contractAddress,
           from: account.address,
           data: expect.any(String),
-          block_id: "latest-nonfinal",
+          block_id: BlockId.LATEST_FINAL,
         },
       ],
     });
@@ -63,7 +63,7 @@ describe("Client Overrides", () => {
       address: contractAddress as Address,
       functionName: "testFunction",
       args: ["arg1", "arg2"],
-      blockId: "latest-final",
+      blockId: BlockId.LATEST_NONFINAL,
       leaderResults: {"0": "0x0123456789012345678901234567890123456789"},
     });
 
@@ -74,7 +74,7 @@ describe("Client Overrides", () => {
           to: contractAddress,
           from: overrideAccount.address,
           data: expect.any(String),
-          block_id: "latest-final",
+          block_id: BlockId.LATEST_NONFINAL,
           leader_results: {"0": "0x0123456789012345678901234567890123456789"},
         },
       ],
@@ -104,6 +104,44 @@ describe("Client Overrides", () => {
           to: contractAddress,
           from: account,
           data: expect.any(String),
+        },
+      ],
+    });
+
+    await client.readContract({
+      address: contractAddress as Address,
+      functionName: "testFunction",
+      args: ["arg1", "arg2"],
+      blockId: createArchiveBlockId(1234567),
+    });
+
+    expect(client.request).toHaveBeenCalledWith({
+      method: "gen_call",
+      params: [
+        {
+          to: contractAddress,
+          from: account,
+          data: expect.any(String),
+          block_id: createArchiveBlockId(1234567),
+        },
+      ],
+    });
+
+    await client.readContract({
+      address: contractAddress as Address,
+      functionName: "testFunction",
+      args: ["arg1", "arg2"],
+      blockId: createArchiveBlockId("0xabc1234567890123456789012345678901234567"),
+    });
+
+    expect(client.request).toHaveBeenCalledWith({
+      method: "gen_call",
+      params: [
+        {
+          to: contractAddress,
+          from: account,
+          data: expect.any(String),
+          block_id: createArchiveBlockId("0xabc1234567890123456789012345678901234567"),
         },
       ],
     });


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #71 

# What

<!-- Describe the changes you made. -->

- Changed from eth_call to gen_call in readContract.
- Added blockId and leaderResults arguments to readContract.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To be able to read the contract state for accepted and finalized.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the new feature with the studio.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->
Not using eth_call. Should I make a case to use the eth_call when blockId is empty?

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
Check code changes. Call the read method.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
Add gen_call in readContract instead of eth_call.