### PR TITLE
feat: overwrite max rotations

### DIFF
--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -52,6 +52,7 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
       value: bigint;
       leaderOnly?: boolean;
+      consensusMaxRotations?: number;
     }) => Promise<any>;
     deployContract: (args: {
       account?: Account;
@@ -59,6 +60,7 @@ export type GenLayerClient<TSimulatorChain extends SimulatorChain> = Omit<
       args?: CalldataEncodable[];
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
       leaderOnly?: boolean;
+      consensusMaxRotations?: number;
     }) => Promise<`0x${string}`>;
     getTransaction: (args: {hash: TransactionHash}) => Promise<GenLayerTransaction>;
     getCurrentNonce: (args: {address: string}) => Promise<number>;


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #74

# What

- Added an optional `consensusMaxRotations` parameter to contract interaction methods.
- Modified `_sendTransaction` to accept and use the custom consensus rotations parameter.
- Updated type definitions to include the new parameter.

# Why

- To allow fine-grained control over consensus max rotations at the transaction level.
- Previously, consensus max rotations was fixed to the chain's default value.
- This change enables users to set the max rotations per transaction.

# Testing done

- Tested contract deployment and write with custom consensus max rotations with studio.

# Decisions made

- Made `consensusMaxRotations` optional with a default value from `client.chain.defaultConsensusMaxRotations`.
- Maintained backward compatibility by using the chain's default value when parameter is not provided.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Focus on the parameter passing flow from the public methods through to `_sendTransaction`.
- Verify that the default behavior remains unchanged.
- Check type definitions for completeness.

# User facing release notes
Added option to specify the maximum number of consensus rotations per transaction.