### PR TITLE
feat: decoding params

### DIFF
--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -31,6 +31,7 @@ export type GenLayerTransaction = {
       node_config: Record<string, unknown>;
       pending_transactions: unknown[];
       vote: string;
+      result: string;
     };
     validators?: Record<string, unknown>[];
     votes?: Record<string, string>;

--- a/src/utils/jsonifier.ts
+++ b/src/utils/jsonifier.ts
@@ -1,0 +1,47 @@
+import {calldata} from "@/abi";
+
+
+export function b64ToArray(b64: string): Uint8Array {
+  return Uint8Array.from(atob(b64 as string), (c) => c.charCodeAt(0));
+}
+
+export function calldataToUserFriendlyJson(cd: Uint8Array): any {
+  return {
+    raw: Array.from(cd),
+    readable: calldata.toString(calldata.decode(cd)),
+  };
+}
+
+const RESULT_CODES = new Map([
+  [0, 'return'],
+  [1, 'rollback'],
+  [2, 'contract_error'],
+  [3, 'error'],
+  [4, 'none'],
+  [5, 'no_leaders'],
+]);
+
+export function resultToUserFriendlyJson(cd64: string): any {
+  const raw = b64ToArray(cd64);
+
+  const code = RESULT_CODES.get(raw[0]);
+  let status: string;
+  let payload: string | null = null;
+
+  if (code === undefined) {
+    status = '<unknown>';
+  } else {
+    status = code;
+    if ([1, 2].includes(raw[0])) {
+      payload = new TextDecoder('utf-8').decode(raw.slice(1));
+    } else if (raw[0] == 0) {
+      payload = calldataToUserFriendlyJson(raw.slice(1));
+    }
+  }
+
+  return {
+    raw: cd64,
+    status,
+    payload,
+  };
+}


### PR DESCRIPTION
Fixes #70 

# What

- Updated waitForTransactionReceipt to return decoded calldata and result.
- Ensured it follows the same behavior as Studio implementation.
- Now, other applications using this function don't need to implement their own decoding.

# Why

- Simplifies transaction handling for external applications.
- Eliminates redundant decoding logic across different projects.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Verified that transactions now return pre-decoded calldata and result (tested using the CLI)
- Checked that no existing functionality was broken.

# Decisions made

- Decoding is now centralized inside transactionActions.ts to avoid duplication.
- Maintained a single try-catch block to handle all decoding failures.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# User facing release notes

- Transactions now return pre-decoded calldata and result.
- Applications no longer need to implement their own decoding—saving time and reducing complexity.
- This update aligns waitForTransactionReceipt with Studio's transaction processing behavior.
