### PR TITLE
refactor: add default consensus main contract to genlayerjs

### DIFF
--- a/src/chains/actions.ts
+++ b/src/chains/actions.ts
@@ -1,10 +1,10 @@
 import {GenLayerClient, GenLayerChain} from "@/types";
-import {testnet} from "./testnet";
+import {testnetAsimov} from "./testnetAsimov";
 
 export function chainActions(client: GenLayerClient<GenLayerChain>) {
   return {
     initializeConsensusSmartContract: async (forceReset: boolean = false): Promise<void> => {
-      if (client.chain?.id === testnet.id) {
+      if (client.chain?.id === testnetAsimov.id) {
         return;
       }
 

--- a/src/chains/actions.ts
+++ b/src/chains/actions.ts
@@ -4,7 +4,7 @@ import {testnet} from "./testnet";
 export function chainActions(client: GenLayerClient<GenLayerChain>) {
   return {
     initializeConsensusSmartContract: async (forceReset: boolean = false): Promise<void> => {
-      if (client.chain?.id !== testnet.id) {
+      if (client.chain?.id === testnet.id) {
         return;
       }
 

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -1,3 +1,3 @@
 // src/chains/index.ts
 export {localnet} from "./localnet";
-export {testnet} from "./testnet";
+export {testnetAsimov} from "./testnetAsimov";

--- a/src/chains/localnet.ts
+++ b/src/chains/localnet.ts
@@ -1,8 +1,3991 @@
-import {defineChain} from "viem";
+import {Address, defineChain} from "viem";
 import {GenLayerChain} from "@/types";
 
 // chains/localnet.ts
 const SIMULATOR_JSON_RPC_URL = "http://127.0.0.1:4000/api";
+const CONSENSUS_MAIN_CONTRACT = {
+  address: "0xb7278A61aa25c888815aFC32Ad3cC52fF24fE575" as Address,
+  abi: [
+    {
+      inputs: [],
+      name: "AccessControlBadConfirmation",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          internalType: "bytes32",
+          name: "neededRole",
+          type: "bytes32",
+        },
+      ],
+      name: "AccessControlUnauthorizedAccount",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "CallerNotMessages",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "CanNotAppeal",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "EmptyTransaction",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "FinalizationNotAllowed",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "InvalidAddress",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "InvalidGhostContract",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "InvalidInitialization",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "InvalidVote",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "MaxNumOfIterationsInPendingQueueReached",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "uint256",
+          name: "numOfMessages",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "maxAllocatedMessages",
+          type: "uint256",
+        },
+      ],
+      name: "MaxNumOfMessagesExceeded",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "NonGenVMContract",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "NotInitializing",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "owner",
+          type: "address",
+        },
+      ],
+      name: "OwnableInvalidOwner",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "OwnableUnauthorizedAccount",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "ReentrancyGuardReentrantCall",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "TransactionNotAtPendingQueueHead",
+      type: "error",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "appealer",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "uint256",
+          name: "appealBond",
+          type: "uint256",
+        },
+        {
+          indexed: false,
+          internalType: "address[]",
+          name: "appealValidators",
+          type: "address[]",
+        },
+      ],
+      name: "AppealStarted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "bytes",
+          name: "data",
+          type: "bytes",
+        },
+      ],
+      name: "ErrorMessage",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: "address",
+          name: "ghostFactory",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "genManager",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "genTransactions",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "genQueue",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "genStaking",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "genMessages",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "idleness",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "tribunalAppeal",
+          type: "address",
+        },
+      ],
+      name: "ExternalContractsSet",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: "uint64",
+          name: "version",
+          type: "uint64",
+        },
+      ],
+      name: "Initialized",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "activator",
+          type: "address",
+        },
+      ],
+      name: "InternalMessageProcessed",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "activator",
+          type: "address",
+        },
+      ],
+      name: "NewTransaction",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "previousOwner",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "OwnershipTransferStarted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "previousOwner",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "OwnershipTransferred",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "previousAdminRole",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "newAdminRole",
+          type: "bytes32",
+        },
+      ],
+      name: "RoleAdminChanged",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "RoleGranted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "RoleRevoked",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "SlashAppealSubmitted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "TransactionAccepted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "leader",
+          type: "address",
+        },
+      ],
+      name: "TransactionActivated",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "uint256",
+          name: "batchId",
+          type: "uint256",
+        },
+        {
+          indexed: false,
+          internalType: "address[]",
+          name: "validators",
+          type: "address[]",
+        },
+      ],
+      name: "TransactionActivatedValidators",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "TransactionCancelled",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "TransactionFinalized",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "oldValidator",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newValidator",
+          type: "address",
+        },
+      ],
+      name: "TransactionIdleValidatorReplaced",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "uint256",
+          name: "validatorIndex",
+          type: "uint256",
+        },
+      ],
+      name: "TransactionIdleValidatorReplacementFailed",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newLeader",
+          type: "address",
+        },
+      ],
+      name: "TransactionLeaderRotated",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "TransactionLeaderTimeout",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: "bytes32[]",
+          name: "tx_ids",
+          type: "bytes32[]",
+        },
+      ],
+      name: "TransactionNeedsRecomputation",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "tx_id",
+          type: "bytes32",
+        },
+        {
+          indexed: false,
+          internalType: "address[]",
+          name: "validators",
+          type: "address[]",
+        },
+      ],
+      name: "TransactionReceiptProposed",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "TransactionUndetermined",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "validator",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "bool",
+          name: "isLastVote",
+          type: "bool",
+        },
+      ],
+      name: "TribunalAppealVoteCommitted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "validator",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "bool",
+          name: "isLastVote",
+          type: "bool",
+        },
+      ],
+      name: "TribunalAppealVoteRevealed",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "validator",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "bool",
+          name: "isLastVote",
+          type: "bool",
+        },
+      ],
+      name: "VoteCommitted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "validator",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "enum ITransactions.VoteType",
+          name: "voteType",
+          type: "uint8",
+        },
+        {
+          indexed: false,
+          internalType: "bool",
+          name: "isLastVote",
+          type: "bool",
+        },
+        {
+          indexed: false,
+          internalType: "enum ITransactions.ResultType",
+          name: "result",
+          type: "uint8",
+        },
+      ],
+      name: "VoteRevealed",
+      type: "event",
+    },
+    {
+      inputs: [],
+      name: "DEFAULT_ADMIN_ROLE",
+      outputs: [
+        {
+          internalType: "bytes32",
+          name: "",
+          type: "bytes32",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "EVENTS_BATCH_SIZE",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "acceptOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes",
+          name: "_vrfProof",
+          type: "bytes",
+        },
+      ],
+      name: "activateTransaction",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_sender",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "_numOfInitialValidators",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "_maxRotations",
+          type: "uint256",
+        },
+        {
+          internalType: "bytes",
+          name: "_txData",
+          type: "bytes",
+        },
+      ],
+      name: "addTransaction",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+      ],
+      name: "cancelTransaction",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes32",
+          name: "_commitHash",
+          type: "bytes32",
+        },
+      ],
+      name: "commitTribunalAppealVote",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes32",
+          name: "_commitHash",
+          type: "bytes32",
+        },
+        {
+          internalType: "uint256",
+          name: "_validatorIndex",
+          type: "uint256",
+        },
+      ],
+      name: "commitVote",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "contracts",
+      outputs: [
+        {
+          internalType: "contract IGenManager",
+          name: "genManager",
+          type: "address",
+        },
+        {
+          internalType: "contract ITransactions",
+          name: "genTransactions",
+          type: "address",
+        },
+        {
+          internalType: "contract IQueues",
+          name: "genQueue",
+          type: "address",
+        },
+        {
+          internalType: "contract IGhostFactory",
+          name: "ghostFactory",
+          type: "address",
+        },
+        {
+          internalType: "contract IGenStaking",
+          name: "genStaking",
+          type: "address",
+        },
+        {
+          internalType: "contract IMessages",
+          name: "genMessages",
+          type: "address",
+        },
+        {
+          internalType: "contract IIdleness",
+          name: "idleness",
+          type: "address",
+        },
+        {
+          internalType: "contract ITribunalAppeal",
+          name: "tribunalAppeal",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "_value",
+          type: "uint256",
+        },
+        {
+          internalType: "bytes",
+          name: "_data",
+          type: "bytes",
+        },
+      ],
+      name: "executeMessage",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "success",
+          type: "bool",
+        },
+      ],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+      ],
+      name: "finalizeTransaction",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "getContracts",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "contract IGenManager",
+              name: "genManager",
+              type: "address",
+            },
+            {
+              internalType: "contract ITransactions",
+              name: "genTransactions",
+              type: "address",
+            },
+            {
+              internalType: "contract IQueues",
+              name: "genQueue",
+              type: "address",
+            },
+            {
+              internalType: "contract IGhostFactory",
+              name: "ghostFactory",
+              type: "address",
+            },
+            {
+              internalType: "contract IGenStaking",
+              name: "genStaking",
+              type: "address",
+            },
+            {
+              internalType: "contract IMessages",
+              name: "genMessages",
+              type: "address",
+            },
+            {
+              internalType: "contract IIdleness",
+              name: "idleness",
+              type: "address",
+            },
+            {
+              internalType: "contract ITribunalAppeal",
+              name: "tribunalAppeal",
+              type: "address",
+            },
+          ],
+          internalType: "struct IConsensusMain.ExternalContracts",
+          name: "",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+      ],
+      name: "getRoleAdmin",
+      outputs: [
+        {
+          internalType: "bytes32",
+          name: "",
+          type: "bytes32",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "addr",
+          type: "address",
+        },
+      ],
+      name: "ghostContracts",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "isGhost",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "grantRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "hasRole",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "initialize",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "owner",
+      outputs: [
+        {
+          internalType: "address",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "pendingOwner",
+      outputs: [
+        {
+          internalType: "address",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "proceedPendingQueueProcessing",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes",
+          name: "_txReceipt",
+          type: "bytes",
+        },
+        {
+          internalType: "uint256",
+          name: "_processingBlock",
+          type: "uint256",
+        },
+        {
+          components: [
+            {
+              internalType: "enum IMessages.MessageType",
+              name: "messageType",
+              type: "uint8",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "value",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes",
+              name: "data",
+              type: "bytes",
+            },
+            {
+              internalType: "bool",
+              name: "onAcceptance",
+              type: "bool",
+            },
+          ],
+          internalType: "struct IMessages.SubmittedMessage[]",
+          name: "_messages",
+          type: "tuple[]",
+        },
+        {
+          internalType: "bytes",
+          name: "_vrfProof",
+          type: "bytes",
+        },
+      ],
+      name: "proposeReceipt",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "renounceOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "callerConfirmation",
+          type: "address",
+        },
+      ],
+      name: "renounceRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes32",
+          name: "_voteHash",
+          type: "bytes32",
+        },
+        {
+          internalType: "enum ITribunalAppeal.TribunalVoteType",
+          name: "_voteType",
+          type: "uint8",
+        },
+        {
+          internalType: "uint256",
+          name: "_nonce",
+          type: "uint256",
+        },
+      ],
+      name: "revealTribunalAppealVote",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes32",
+          name: "_voteHash",
+          type: "bytes32",
+        },
+        {
+          internalType: "enum ITransactions.VoteType",
+          name: "_voteType",
+          type: "uint8",
+        },
+        {
+          internalType: "uint256",
+          name: "_nonce",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "_validatorIndex",
+          type: "uint256",
+        },
+      ],
+      name: "revealVote",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "revokeRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_ghostFactory",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_genManager",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_genTransactions",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_genQueue",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_genStaking",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_genMessages",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_idleness",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_tribunalAppeal",
+          type: "address",
+        },
+      ],
+      name: "setExternalContracts",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+      ],
+      name: "submitAppeal",
+      outputs: [],
+      stateMutability: "payable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+      ],
+      name: "submitSlashAppeal",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes4",
+          name: "interfaceId",
+          type: "bytes4",
+        },
+      ],
+      name: "supportsInterface",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "transferOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+  ],
+  bytecode: "",
+};
+
+const CONSENSUS_DATA_CONTRACT = {
+  address: "0x88B0F18613Db92Bf970FfE264E02496e20a74D16" as Address,
+  abi: [
+    {
+      inputs: [],
+      name: "AccessControlBadConfirmation",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          internalType: "bytes32",
+          name: "neededRole",
+          type: "bytes32",
+        },
+      ],
+      name: "AccessControlUnauthorizedAccount",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "InvalidInitialization",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "NotInitializing",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "owner",
+          type: "address",
+        },
+      ],
+      name: "OwnableInvalidOwner",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "OwnableUnauthorizedAccount",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "ReentrancyGuardReentrantCall",
+      type: "error",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: "uint64",
+          name: "version",
+          type: "uint64",
+        },
+      ],
+      name: "Initialized",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "previousOwner",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "OwnershipTransferStarted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "previousOwner",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "OwnershipTransferred",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "previousAdminRole",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "newAdminRole",
+          type: "bytes32",
+        },
+      ],
+      name: "RoleAdminChanged",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "RoleGranted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "RoleRevoked",
+      type: "event",
+    },
+    {
+      inputs: [],
+      name: "DEFAULT_ADMIN_ROLE",
+      outputs: [
+        {
+          internalType: "bytes32",
+          name: "",
+          type: "bytes32",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "acceptOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "uint256",
+          name: "_currentTimestamp",
+          type: "uint256",
+        },
+      ],
+      name: "canFinalize",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "consensusMain",
+      outputs: [
+        {
+          internalType: "contract IConsensusMain",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getLastAppealResult",
+      outputs: [
+        {
+          internalType: "enum ITransactions.ResultType",
+          name: "",
+          type: "uint8",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestAcceptedTransaction",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData",
+          name: "txData",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "startIndex",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "pageSize",
+          type: "uint256",
+        },
+      ],
+      name: "getLatestAcceptedTransactions",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData[]",
+          name: "",
+          type: "tuple[]",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestAcceptedTxCount",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestFinalizedTransaction",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData",
+          name: "txData",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "startIndex",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "pageSize",
+          type: "uint256",
+        },
+      ],
+      name: "getLatestFinalizedTransactions",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData[]",
+          name: "",
+          type: "tuple[]",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestFinalizedTxCount",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestPendingTxCount",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "slot",
+          type: "uint256",
+        },
+      ],
+      name: "getLatestPendingTxId",
+      outputs: [
+        {
+          internalType: "bytes32",
+          name: "",
+          type: "bytes32",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestUndeterminedTransaction",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData",
+          name: "txData",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestUndeterminedTxCount",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getMessagesForTransaction",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "enum IMessages.MessageType",
+              name: "messageType",
+              type: "uint8",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "value",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes",
+              name: "data",
+              type: "bytes",
+            },
+            {
+              internalType: "bool",
+              name: "onAcceptance",
+              type: "bool",
+            },
+          ],
+          internalType: "struct IMessages.SubmittedMessage[]",
+          name: "",
+          type: "tuple[]",
+        },
+        {
+          internalType: "address",
+          name: "ghostAddress",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getReadStateBlockRangeForTransaction",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "activationBlock",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "processingBlock",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "proposalBlock",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "startIndex",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "endIndex",
+          type: "uint256",
+        },
+      ],
+      name: "getRecipientQueues",
+      outputs: [
+        {
+          components: [
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "head",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "tail",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "txIds",
+                  type: "bytes32[]",
+                },
+              ],
+              internalType: "struct IQueues.QueueInfoView",
+              name: "pending",
+              type: "tuple",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "head",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "tail",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "txIds",
+                  type: "bytes32[]",
+                },
+              ],
+              internalType: "struct IQueues.QueueInfoView",
+              name: "accepted",
+              type: "tuple",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "head",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "tail",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "txIds",
+                  type: "bytes32[]",
+                },
+              ],
+              internalType: "struct IQueues.QueueInfoView",
+              name: "undetermined",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "finalizedCount",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "issuedTxCount",
+              type: "uint256",
+            },
+          ],
+          internalType: "struct IQueues.RecipientQueuesView",
+          name: "",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+      ],
+      name: "getRoleAdmin",
+      outputs: [
+        {
+          internalType: "bytes32",
+          name: "",
+          type: "bytes32",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "getTotalNumOfTransactions",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getTransactionAllData",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "bytes32",
+              name: "id",
+              type: "bytes32",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "previousStatus",
+              type: "uint8",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "created",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "pending",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "activated",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "committed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "lastVote",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealSubmitted",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.Timestamps",
+              name: "timestamps",
+              type: "tuple",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "bool",
+              name: "onAcceptanceMessages",
+              type: "bool",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "address[]",
+              name: "consumedValidators",
+              type: "address[]",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData[]",
+              name: "roundData",
+              type: "tuple[]",
+            },
+          ],
+          internalType: "struct ITransactions.Transaction",
+          name: "transaction",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+        {
+          internalType: "uint256",
+          name: "_timestamp",
+          type: "uint256",
+        },
+      ],
+      name: "getTransactionData",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData",
+          name: "",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "uint256",
+          name: "startIndex",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "endIndex",
+          type: "uint256",
+        },
+      ],
+      name: "getTransactionIndexToTxId",
+      outputs: [
+        {
+          internalType: "bytes32[]",
+          name: "",
+          type: "bytes32[]",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+        {
+          internalType: "uint256",
+          name: "_timestamp",
+          type: "uint256",
+        },
+      ],
+      name: "getTransactionStatus",
+      outputs: [
+        {
+          internalType: "enum ITransactions.TransactionStatus",
+          name: "",
+          type: "uint8",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getValidatorsForLastAppeal",
+      outputs: [
+        {
+          internalType: "address[]",
+          name: "",
+          type: "address[]",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getValidatorsForLastRound",
+      outputs: [
+        {
+          internalType: "address[]",
+          name: "",
+          type: "address[]",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "grantRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "hasRole",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "hasTransactionOnAcceptanceMessages",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "hasTransactionOnFinalizationMessages",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_consensusMain",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_transactions",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_queues",
+          type: "address",
+        },
+      ],
+      name: "initialize",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "owner",
+      outputs: [
+        {
+          internalType: "address",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "pendingOwner",
+      outputs: [
+        {
+          internalType: "address",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "queues",
+      outputs: [
+        {
+          internalType: "contract IQueues",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "renounceOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "callerConfirmation",
+          type: "address",
+        },
+      ],
+      name: "renounceRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "revokeRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_consensusMain",
+          type: "address",
+        },
+      ],
+      name: "setConsensusMain",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_queues",
+          type: "address",
+        },
+      ],
+      name: "setQueues",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_transactions",
+          type: "address",
+        },
+      ],
+      name: "setTransactions",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes4",
+          name: "interfaceId",
+          type: "bytes4",
+        },
+      ],
+      name: "supportsInterface",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "transactions",
+      outputs: [
+        {
+          internalType: "contract ITransactions",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "transferOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+  ],
+  bytecode: "",
+};
 
 export const localnet: GenLayerChain = defineChain({
   id: 61_999,
@@ -24,8 +4007,8 @@ export const localnet: GenLayerChain = defineChain({
     },
   },
   testnet: true,
-  consensusMainContract: null,
-  consensusDataContract: null,
+  consensusMainContract: CONSENSUS_MAIN_CONTRACT,
+  consensusDataContract: CONSENSUS_DATA_CONTRACT,
   defaultNumberOfInitialValidators: 5,
   defaultConsensusMaxRotations: 3,
 });

--- a/src/chains/studionet.ts
+++ b/src/chains/studionet.ts
@@ -1,0 +1,4015 @@
+import {Address, defineChain} from "viem";
+import {GenLayerChain} from "@/types";
+
+// chains/localnet.ts
+const SIMULATOR_JSON_RPC_URL = "https://studio.genlayer.com/api";
+const EXPLORER_URL = "https://genlayer-explorer.vercel.app";
+const CONSENSUS_MAIN_CONTRACT = {
+  address: "0xb7278A61aa25c888815aFC32Ad3cC52fF24fE575" as Address,
+  abi: [
+    {
+      inputs: [],
+      name: "AccessControlBadConfirmation",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          internalType: "bytes32",
+          name: "neededRole",
+          type: "bytes32",
+        },
+      ],
+      name: "AccessControlUnauthorizedAccount",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "CallerNotMessages",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "CanNotAppeal",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "EmptyTransaction",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "FinalizationNotAllowed",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "InvalidAddress",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "InvalidGhostContract",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "InvalidInitialization",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "InvalidVote",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "MaxNumOfIterationsInPendingQueueReached",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "uint256",
+          name: "numOfMessages",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "maxAllocatedMessages",
+          type: "uint256",
+        },
+      ],
+      name: "MaxNumOfMessagesExceeded",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "NonGenVMContract",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "NotInitializing",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "owner",
+          type: "address",
+        },
+      ],
+      name: "OwnableInvalidOwner",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "OwnableUnauthorizedAccount",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "ReentrancyGuardReentrantCall",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "TransactionNotAtPendingQueueHead",
+      type: "error",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "appealer",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "uint256",
+          name: "appealBond",
+          type: "uint256",
+        },
+        {
+          indexed: false,
+          internalType: "address[]",
+          name: "appealValidators",
+          type: "address[]",
+        },
+      ],
+      name: "AppealStarted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "bytes",
+          name: "data",
+          type: "bytes",
+        },
+      ],
+      name: "ErrorMessage",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: "address",
+          name: "ghostFactory",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "genManager",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "genTransactions",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "genQueue",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "genStaking",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "genMessages",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "idleness",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "address",
+          name: "tribunalAppeal",
+          type: "address",
+        },
+      ],
+      name: "ExternalContractsSet",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: "uint64",
+          name: "version",
+          type: "uint64",
+        },
+      ],
+      name: "Initialized",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "activator",
+          type: "address",
+        },
+      ],
+      name: "InternalMessageProcessed",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "activator",
+          type: "address",
+        },
+      ],
+      name: "NewTransaction",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "previousOwner",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "OwnershipTransferStarted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "previousOwner",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "OwnershipTransferred",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "previousAdminRole",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "newAdminRole",
+          type: "bytes32",
+        },
+      ],
+      name: "RoleAdminChanged",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "RoleGranted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "RoleRevoked",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "SlashAppealSubmitted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "TransactionAccepted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "leader",
+          type: "address",
+        },
+      ],
+      name: "TransactionActivated",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "uint256",
+          name: "batchId",
+          type: "uint256",
+        },
+        {
+          indexed: false,
+          internalType: "address[]",
+          name: "validators",
+          type: "address[]",
+        },
+      ],
+      name: "TransactionActivatedValidators",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "TransactionCancelled",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "TransactionFinalized",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "oldValidator",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newValidator",
+          type: "address",
+        },
+      ],
+      name: "TransactionIdleValidatorReplaced",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "uint256",
+          name: "validatorIndex",
+          type: "uint256",
+        },
+      ],
+      name: "TransactionIdleValidatorReplacementFailed",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newLeader",
+          type: "address",
+        },
+      ],
+      name: "TransactionLeaderRotated",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "TransactionLeaderTimeout",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: "bytes32[]",
+          name: "tx_ids",
+          type: "bytes32[]",
+        },
+      ],
+      name: "TransactionNeedsRecomputation",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "tx_id",
+          type: "bytes32",
+        },
+        {
+          indexed: false,
+          internalType: "address[]",
+          name: "validators",
+          type: "address[]",
+        },
+      ],
+      name: "TransactionReceiptProposed",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "TransactionUndetermined",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "validator",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "bool",
+          name: "isLastVote",
+          type: "bool",
+        },
+      ],
+      name: "TribunalAppealVoteCommitted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "validator",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "bool",
+          name: "isLastVote",
+          type: "bool",
+        },
+      ],
+      name: "TribunalAppealVoteRevealed",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "validator",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "bool",
+          name: "isLastVote",
+          type: "bool",
+        },
+      ],
+      name: "VoteCommitted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "txId",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "validator",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "enum ITransactions.VoteType",
+          name: "voteType",
+          type: "uint8",
+        },
+        {
+          indexed: false,
+          internalType: "bool",
+          name: "isLastVote",
+          type: "bool",
+        },
+        {
+          indexed: false,
+          internalType: "enum ITransactions.ResultType",
+          name: "result",
+          type: "uint8",
+        },
+      ],
+      name: "VoteRevealed",
+      type: "event",
+    },
+    {
+      inputs: [],
+      name: "DEFAULT_ADMIN_ROLE",
+      outputs: [
+        {
+          internalType: "bytes32",
+          name: "",
+          type: "bytes32",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "EVENTS_BATCH_SIZE",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "acceptOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes",
+          name: "_vrfProof",
+          type: "bytes",
+        },
+      ],
+      name: "activateTransaction",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_sender",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "_numOfInitialValidators",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "_maxRotations",
+          type: "uint256",
+        },
+        {
+          internalType: "bytes",
+          name: "_txData",
+          type: "bytes",
+        },
+      ],
+      name: "addTransaction",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+      ],
+      name: "cancelTransaction",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes32",
+          name: "_commitHash",
+          type: "bytes32",
+        },
+      ],
+      name: "commitTribunalAppealVote",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes32",
+          name: "_commitHash",
+          type: "bytes32",
+        },
+        {
+          internalType: "uint256",
+          name: "_validatorIndex",
+          type: "uint256",
+        },
+      ],
+      name: "commitVote",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "contracts",
+      outputs: [
+        {
+          internalType: "contract IGenManager",
+          name: "genManager",
+          type: "address",
+        },
+        {
+          internalType: "contract ITransactions",
+          name: "genTransactions",
+          type: "address",
+        },
+        {
+          internalType: "contract IQueues",
+          name: "genQueue",
+          type: "address",
+        },
+        {
+          internalType: "contract IGhostFactory",
+          name: "ghostFactory",
+          type: "address",
+        },
+        {
+          internalType: "contract IGenStaking",
+          name: "genStaking",
+          type: "address",
+        },
+        {
+          internalType: "contract IMessages",
+          name: "genMessages",
+          type: "address",
+        },
+        {
+          internalType: "contract IIdleness",
+          name: "idleness",
+          type: "address",
+        },
+        {
+          internalType: "contract ITribunalAppeal",
+          name: "tribunalAppeal",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "_value",
+          type: "uint256",
+        },
+        {
+          internalType: "bytes",
+          name: "_data",
+          type: "bytes",
+        },
+      ],
+      name: "executeMessage",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "success",
+          type: "bool",
+        },
+      ],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+      ],
+      name: "finalizeTransaction",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "getContracts",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "contract IGenManager",
+              name: "genManager",
+              type: "address",
+            },
+            {
+              internalType: "contract ITransactions",
+              name: "genTransactions",
+              type: "address",
+            },
+            {
+              internalType: "contract IQueues",
+              name: "genQueue",
+              type: "address",
+            },
+            {
+              internalType: "contract IGhostFactory",
+              name: "ghostFactory",
+              type: "address",
+            },
+            {
+              internalType: "contract IGenStaking",
+              name: "genStaking",
+              type: "address",
+            },
+            {
+              internalType: "contract IMessages",
+              name: "genMessages",
+              type: "address",
+            },
+            {
+              internalType: "contract IIdleness",
+              name: "idleness",
+              type: "address",
+            },
+            {
+              internalType: "contract ITribunalAppeal",
+              name: "tribunalAppeal",
+              type: "address",
+            },
+          ],
+          internalType: "struct IConsensusMain.ExternalContracts",
+          name: "",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+      ],
+      name: "getRoleAdmin",
+      outputs: [
+        {
+          internalType: "bytes32",
+          name: "",
+          type: "bytes32",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "addr",
+          type: "address",
+        },
+      ],
+      name: "ghostContracts",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "isGhost",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "grantRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "hasRole",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "initialize",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "owner",
+      outputs: [
+        {
+          internalType: "address",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "pendingOwner",
+      outputs: [
+        {
+          internalType: "address",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "proceedPendingQueueProcessing",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes",
+          name: "_txReceipt",
+          type: "bytes",
+        },
+        {
+          internalType: "uint256",
+          name: "_processingBlock",
+          type: "uint256",
+        },
+        {
+          components: [
+            {
+              internalType: "enum IMessages.MessageType",
+              name: "messageType",
+              type: "uint8",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "value",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes",
+              name: "data",
+              type: "bytes",
+            },
+            {
+              internalType: "bool",
+              name: "onAcceptance",
+              type: "bool",
+            },
+          ],
+          internalType: "struct IMessages.SubmittedMessage[]",
+          name: "_messages",
+          type: "tuple[]",
+        },
+        {
+          internalType: "bytes",
+          name: "_vrfProof",
+          type: "bytes",
+        },
+      ],
+      name: "proposeReceipt",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "renounceOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "callerConfirmation",
+          type: "address",
+        },
+      ],
+      name: "renounceRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes32",
+          name: "_voteHash",
+          type: "bytes32",
+        },
+        {
+          internalType: "enum ITribunalAppeal.TribunalVoteType",
+          name: "_voteType",
+          type: "uint8",
+        },
+        {
+          internalType: "uint256",
+          name: "_nonce",
+          type: "uint256",
+        },
+      ],
+      name: "revealTribunalAppealVote",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "bytes32",
+          name: "_voteHash",
+          type: "bytes32",
+        },
+        {
+          internalType: "enum ITransactions.VoteType",
+          name: "_voteType",
+          type: "uint8",
+        },
+        {
+          internalType: "uint256",
+          name: "_nonce",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "_validatorIndex",
+          type: "uint256",
+        },
+      ],
+      name: "revealVote",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "revokeRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_ghostFactory",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_genManager",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_genTransactions",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_genQueue",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_genStaking",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_genMessages",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_idleness",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_tribunalAppeal",
+          type: "address",
+        },
+      ],
+      name: "setExternalContracts",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+      ],
+      name: "submitAppeal",
+      outputs: [],
+      stateMutability: "payable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+      ],
+      name: "submitSlashAppeal",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes4",
+          name: "interfaceId",
+          type: "bytes4",
+        },
+      ],
+      name: "supportsInterface",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "transferOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+  ],
+  bytecode: "",
+};
+
+const CONSENSUS_DATA_CONTRACT = {
+  address: "0x88B0F18613Db92Bf970FfE264E02496e20a74D16" as Address,
+  abi: [
+    {
+      inputs: [],
+      name: "AccessControlBadConfirmation",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          internalType: "bytes32",
+          name: "neededRole",
+          type: "bytes32",
+        },
+      ],
+      name: "AccessControlUnauthorizedAccount",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "InvalidInitialization",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "NotInitializing",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "owner",
+          type: "address",
+        },
+      ],
+      name: "OwnableInvalidOwner",
+      type: "error",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "OwnableUnauthorizedAccount",
+      type: "error",
+    },
+    {
+      inputs: [],
+      name: "ReentrancyGuardReentrantCall",
+      type: "error",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: "uint64",
+          name: "version",
+          type: "uint64",
+        },
+      ],
+      name: "Initialized",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "previousOwner",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "OwnershipTransferStarted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "previousOwner",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "OwnershipTransferred",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "previousAdminRole",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "newAdminRole",
+          type: "bytes32",
+        },
+      ],
+      name: "RoleAdminChanged",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "RoleGranted",
+      type: "event",
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+      ],
+      name: "RoleRevoked",
+      type: "event",
+    },
+    {
+      inputs: [],
+      name: "DEFAULT_ADMIN_ROLE",
+      outputs: [
+        {
+          internalType: "bytes32",
+          name: "",
+          type: "bytes32",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "acceptOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_txId",
+          type: "bytes32",
+        },
+        {
+          internalType: "uint256",
+          name: "_currentTimestamp",
+          type: "uint256",
+        },
+      ],
+      name: "canFinalize",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "consensusMain",
+      outputs: [
+        {
+          internalType: "contract IConsensusMain",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getLastAppealResult",
+      outputs: [
+        {
+          internalType: "enum ITransactions.ResultType",
+          name: "",
+          type: "uint8",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestAcceptedTransaction",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData",
+          name: "txData",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "startIndex",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "pageSize",
+          type: "uint256",
+        },
+      ],
+      name: "getLatestAcceptedTransactions",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData[]",
+          name: "",
+          type: "tuple[]",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestAcceptedTxCount",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestFinalizedTransaction",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData",
+          name: "txData",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "startIndex",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "pageSize",
+          type: "uint256",
+        },
+      ],
+      name: "getLatestFinalizedTransactions",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData[]",
+          name: "",
+          type: "tuple[]",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestFinalizedTxCount",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestPendingTxCount",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "slot",
+          type: "uint256",
+        },
+      ],
+      name: "getLatestPendingTxId",
+      outputs: [
+        {
+          internalType: "bytes32",
+          name: "",
+          type: "bytes32",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestUndeterminedTransaction",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData",
+          name: "txData",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+      ],
+      name: "getLatestUndeterminedTxCount",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getMessagesForTransaction",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "enum IMessages.MessageType",
+              name: "messageType",
+              type: "uint8",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "value",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes",
+              name: "data",
+              type: "bytes",
+            },
+            {
+              internalType: "bool",
+              name: "onAcceptance",
+              type: "bool",
+            },
+          ],
+          internalType: "struct IMessages.SubmittedMessage[]",
+          name: "",
+          type: "tuple[]",
+        },
+        {
+          internalType: "address",
+          name: "ghostAddress",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getReadStateBlockRangeForTransaction",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "activationBlock",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "processingBlock",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "proposalBlock",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "recipient",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "startIndex",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "endIndex",
+          type: "uint256",
+        },
+      ],
+      name: "getRecipientQueues",
+      outputs: [
+        {
+          components: [
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "head",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "tail",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "txIds",
+                  type: "bytes32[]",
+                },
+              ],
+              internalType: "struct IQueues.QueueInfoView",
+              name: "pending",
+              type: "tuple",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "head",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "tail",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "txIds",
+                  type: "bytes32[]",
+                },
+              ],
+              internalType: "struct IQueues.QueueInfoView",
+              name: "accepted",
+              type: "tuple",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "head",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "tail",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "txIds",
+                  type: "bytes32[]",
+                },
+              ],
+              internalType: "struct IQueues.QueueInfoView",
+              name: "undetermined",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "finalizedCount",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "issuedTxCount",
+              type: "uint256",
+            },
+          ],
+          internalType: "struct IQueues.RecipientQueuesView",
+          name: "",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+      ],
+      name: "getRoleAdmin",
+      outputs: [
+        {
+          internalType: "bytes32",
+          name: "",
+          type: "bytes32",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "getTotalNumOfTransactions",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getTransactionAllData",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "bytes32",
+              name: "id",
+              type: "bytes32",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "previousStatus",
+              type: "uint8",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "created",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "pending",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "activated",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "committed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "lastVote",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealSubmitted",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.Timestamps",
+              name: "timestamps",
+              type: "tuple",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "bool",
+              name: "onAcceptanceMessages",
+              type: "bool",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "address[]",
+              name: "consumedValidators",
+              type: "address[]",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData[]",
+              name: "roundData",
+              type: "tuple[]",
+            },
+          ],
+          internalType: "struct ITransactions.Transaction",
+          name: "transaction",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+        {
+          internalType: "uint256",
+          name: "_timestamp",
+          type: "uint256",
+        },
+      ],
+      name: "getTransactionData",
+      outputs: [
+        {
+          components: [
+            {
+              internalType: "uint256",
+              name: "currentTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "sender",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfInitialValidators",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "txSlot",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "createdTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "lastVoteTimestamp",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes32",
+              name: "randomSeed",
+              type: "bytes32",
+            },
+            {
+              internalType: "enum ITransactions.ResultType",
+              name: "result",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes",
+              name: "txData",
+              type: "bytes",
+            },
+            {
+              internalType: "bytes",
+              name: "txReceipt",
+              type: "bytes",
+            },
+            {
+              components: [
+                {
+                  internalType: "enum IMessages.MessageType",
+                  name: "messageType",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address",
+                  name: "recipient",
+                  type: "address",
+                },
+                {
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+                {
+                  internalType: "bytes",
+                  name: "data",
+                  type: "bytes",
+                },
+                {
+                  internalType: "bool",
+                  name: "onAcceptance",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct IMessages.SubmittedMessage[]",
+              name: "messages",
+              type: "tuple[]",
+            },
+            {
+              internalType: "enum IQueues.QueueType",
+              name: "queueType",
+              type: "uint8",
+            },
+            {
+              internalType: "uint256",
+              name: "queuePosition",
+              type: "uint256",
+            },
+            {
+              internalType: "address",
+              name: "activator",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "lastLeader",
+              type: "address",
+            },
+            {
+              internalType: "enum ITransactions.TransactionStatus",
+              name: "status",
+              type: "uint8",
+            },
+            {
+              internalType: "bytes32",
+              name: "txId",
+              type: "bytes32",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "activationBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "processingBlock",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "proposalBlock",
+                  type: "uint256",
+                },
+              ],
+              internalType: "struct ITransactions.ReadStateBlockRange",
+              name: "readStateBlockRange",
+              type: "tuple",
+            },
+            {
+              internalType: "uint256",
+              name: "numOfRounds",
+              type: "uint256",
+            },
+            {
+              components: [
+                {
+                  internalType: "uint256",
+                  name: "round",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "leaderIndex",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesCommitted",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "votesRevealed",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "appealBond",
+                  type: "uint256",
+                },
+                {
+                  internalType: "uint256",
+                  name: "rotationsLeft",
+                  type: "uint256",
+                },
+                {
+                  internalType: "enum ITransactions.ResultType",
+                  name: "result",
+                  type: "uint8",
+                },
+                {
+                  internalType: "address[]",
+                  name: "roundValidators",
+                  type: "address[]",
+                },
+                {
+                  internalType: "bytes32[]",
+                  name: "validatorVotesHash",
+                  type: "bytes32[]",
+                },
+                {
+                  internalType: "enum ITransactions.VoteType[]",
+                  name: "validatorVotes",
+                  type: "uint8[]",
+                },
+              ],
+              internalType: "struct ITransactions.RoundData",
+              name: "lastRound",
+              type: "tuple",
+            },
+          ],
+          internalType: "struct ConsensusData.TransactionData",
+          name: "",
+          type: "tuple",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "uint256",
+          name: "startIndex",
+          type: "uint256",
+        },
+        {
+          internalType: "uint256",
+          name: "endIndex",
+          type: "uint256",
+        },
+      ],
+      name: "getTransactionIndexToTxId",
+      outputs: [
+        {
+          internalType: "bytes32[]",
+          name: "",
+          type: "bytes32[]",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+        {
+          internalType: "uint256",
+          name: "_timestamp",
+          type: "uint256",
+        },
+      ],
+      name: "getTransactionStatus",
+      outputs: [
+        {
+          internalType: "enum ITransactions.TransactionStatus",
+          name: "",
+          type: "uint8",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getValidatorsForLastAppeal",
+      outputs: [
+        {
+          internalType: "address[]",
+          name: "",
+          type: "address[]",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "getValidatorsForLastRound",
+      outputs: [
+        {
+          internalType: "address[]",
+          name: "",
+          type: "address[]",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "grantRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "hasRole",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "hasTransactionOnAcceptanceMessages",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "_tx_id",
+          type: "bytes32",
+        },
+      ],
+      name: "hasTransactionOnFinalizationMessages",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_consensusMain",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_transactions",
+          type: "address",
+        },
+        {
+          internalType: "address",
+          name: "_queues",
+          type: "address",
+        },
+      ],
+      name: "initialize",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "owner",
+      outputs: [
+        {
+          internalType: "address",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "pendingOwner",
+      outputs: [
+        {
+          internalType: "address",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "queues",
+      outputs: [
+        {
+          internalType: "contract IQueues",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "renounceOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "callerConfirmation",
+          type: "address",
+        },
+      ],
+      name: "renounceRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes32",
+          name: "role",
+          type: "bytes32",
+        },
+        {
+          internalType: "address",
+          name: "account",
+          type: "address",
+        },
+      ],
+      name: "revokeRole",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_consensusMain",
+          type: "address",
+        },
+      ],
+      name: "setConsensusMain",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_queues",
+          type: "address",
+        },
+      ],
+      name: "setQueues",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "_transactions",
+          type: "address",
+        },
+      ],
+      name: "setTransactions",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "bytes4",
+          name: "interfaceId",
+          type: "bytes4",
+        },
+      ],
+      name: "supportsInterface",
+      outputs: [
+        {
+          internalType: "bool",
+          name: "",
+          type: "bool",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "transactions",
+      outputs: [
+        {
+          internalType: "contract ITransactions",
+          name: "",
+          type: "address",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "newOwner",
+          type: "address",
+        },
+      ],
+      name: "transferOwnership",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+  ],
+  bytecode: "",
+};
+
+export const studionet: GenLayerChain = defineChain({
+  id: 61_999,
+  name: "Genlayer Studio Network",
+  rpcUrls: {
+    default: {
+      http: [SIMULATOR_JSON_RPC_URL],
+    },
+  },
+  nativeCurrency: {
+    name: "GEN Token",
+    symbol: "GEN",
+    decimals: 18,
+  },
+  blockExplorers: {
+    default: {
+      name: "GenLayer Explorer",
+      url: EXPLORER_URL,
+    },
+  },
+  testnet: true,
+  consensusMainContract: CONSENSUS_MAIN_CONTRACT,
+  consensusDataContract: CONSENSUS_DATA_CONTRACT,
+  defaultNumberOfInitialValidators: 5,
+  defaultConsensusMaxRotations: 3,
+});

--- a/src/chains/testnetAsimov.ts
+++ b/src/chains/testnetAsimov.ts
@@ -3,7 +3,7 @@ import {GenLayerChain} from "@/types";
 
 // chains/localnet.ts
 const TESTNET_JSON_RPC_URL = " http://34.32.169.58:9151";
-
+const EXPLORER_URL = "https://explorer-asimov.genlayer.com/";
 const CONSENSUS_MAIN_CONTRACT = {
   address: "0x174782d5819dD26F3d6967c995EE43db7DB824F8" as Address,
   abi: [
@@ -3988,9 +3988,9 @@ const CONSENSUS_DATA_CONTRACT = {
   bytecode: "",
 };
 
-export const testnet: GenLayerChain = defineChain({
+export const testnetAsimov: GenLayerChain = defineChain({
   id: 0x107d,
-  name: "Genlayer Testnet",
+  name: "Genlayer Asimov Testnet",
   rpcUrls: {
     default: {
       http: [TESTNET_JSON_RPC_URL],
@@ -4003,8 +4003,8 @@ export const testnet: GenLayerChain = defineChain({
   },
   blockExplorers: {
     default: {
-      name: "GenLayer Explorer",
-      url: "https://explorer-asimov.genlayer.com",
+      name: "GenLayer Asimov Explorer",
+      url: EXPLORER_URL,
     },
   },
   testnet: true,

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -233,6 +233,12 @@ const _sendTransaction = async ({
   const serializedTransaction = await senderAccount.signTransaction(transactionRequest);
 
   const txHash = await client.sendRawTransaction({serializedTransaction: serializedTransaction});
+
+  // TODO: remove this once DXP-298 is merged
+  if (client.chain.id === localnet.id) {
+    return txHash;
+  }
+
   const receipt = await publicClient.waitForTransactionReceipt({hash: txHash});
 
   if (receipt.status === "reverted") {

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -1,7 +1,15 @@
 import * as calldata from "@/abi/calldata";
 import {serialize} from "@/abi/transactions";
 import {localnet} from "@/chains/localnet";
-import {Account, ContractSchema, GenLayerChain, GenLayerClient, CalldataEncodable, Address} from "@/types";
+import {
+  Account,
+  ContractSchema,
+  GenLayerChain,
+  GenLayerClient,
+  CalldataEncodable,
+  Address,
+  TransactionHashVariant,
+} from "@/types";
 import {fromHex, toHex, zeroAddress, encodeFunctionData, PublicClient, parseEventLogs} from "viem";
 
 function makeCalldataObject(
@@ -71,8 +79,17 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
       rawReturn?: RawReturn;
       leaderOnly?: boolean;
+      transactionHashVariant?: TransactionHashVariant;
     }): Promise<RawReturn extends true ? `0x${string}` : CalldataEncodable> => {
-      const {account, address, functionName, args: callArgs, kwargs, leaderOnly = false} = args;
+      const {
+        account,
+        address,
+        functionName,
+        args: callArgs,
+        kwargs,
+        leaderOnly = false,
+        transactionHashVariant = TransactionHashVariant.LATEST_FINAL,
+      } = args;
       const encodedData = [calldata.encode(makeCalldataObject(functionName, callArgs, kwargs)), leaderOnly];
       const serializedData = serialize(encodedData);
 
@@ -83,7 +100,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         to: address,
         from: senderAddress,
         data: serializedData,
-        transaction_hash_variant: "latest-final",
+        transaction_hash_variant: transactionHashVariant,
       };
       const result = await client.request({
         method: "gen_call",

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -75,6 +75,7 @@ export const transactionActions = (client: GenLayerClient<GenLayerChain>, public
         (transaction.status as string) === "ACTIVATED" ? TransactionStatus.PENDING : transaction.status;
 
       transaction.status = Number(transactionsStatusNameToNumber[localnetStatus as TransactionStatus]);
+      transaction.statusName = localnetStatus as TransactionStatus;
       return _decodeLocalnetTransaction(transaction as unknown as GenLayerTransaction);
     }
     const transaction = (await publicClient.readContract({

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -68,6 +68,15 @@ export const receiptActions = (client: GenLayerClient<GenLayerChain>, publicClie
 
 export const transactionActions = (client: GenLayerClient<GenLayerChain>, publicClient: PublicClient) => ({
   getTransaction: async ({hash}: {hash: TransactionHash}): Promise<GenLayerTransaction> => {
+    // TODO: remove this once DXP-298 is merged
+    if (client.chain.id === localnet.id) {
+      const transaction = await client.getTransaction({hash});
+      const localnetStatus =
+        (transaction.status as string) === "ACTIVATED" ? TransactionStatus.PENDING : transaction.status;
+
+      transaction.status = Number(transactionsStatusNameToNumber[localnetStatus as TransactionStatus]);
+      return _decodeLocalnetTransaction(transaction as unknown as GenLayerTransaction);
+    }
     const transaction = (await publicClient.readContract({
       address: client.chain.consensusDataContract?.address as Address,
       abi: client.chain.consensusDataContract?.abi as Abi,
@@ -175,13 +184,14 @@ const _decodeTransaction = (tx: GenLayerRawTransaction): GenLayerTransaction => 
 };
 
 const _decodeLocalnetTransaction = (tx: GenLayerTransaction): GenLayerTransaction => {
+  if (!tx.data) return tx;
   try {
     const leaderReceipt = tx.consensus_data?.leader_receipt;
     if (leaderReceipt) {
-      if (leaderReceipt.result) {
+      if (leaderReceipt.result && typeof leaderReceipt.result === "string") {
         leaderReceipt.result = resultToUserFriendlyJson(leaderReceipt.result);
       }
-      if (leaderReceipt.calldata) {
+      if (leaderReceipt.calldata && typeof leaderReceipt.calldata === "string") {
         leaderReceipt.calldata = {
           base64: leaderReceipt.calldata as string,
           ...calldataToUserFriendlyJson(b64ToArray(leaderReceipt.calldata as string)),
@@ -196,7 +206,7 @@ const _decodeLocalnetTransaction = (tx: GenLayerTransaction): GenLayerTransactio
         );
       }
     }
-    if (tx.data?.calldata) {
+    if (tx.data?.calldata && typeof tx.data.calldata === "string") {
       tx.data.calldata = {
         base64: tx.data.calldata as string,
         ...calldataToUserFriendlyJson(b64ToArray(tx.data.calldata as string)),

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -1,1 +1,1 @@
-export type Network = 'localnet' | 'testnet' | 'mainnet';
+export type Network = "localnet" | "studionet" | "testnetAsimov" | "mainnet";

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -119,6 +119,11 @@ export const voteTypeNameToNumber = {
 
 export type TransactionType = "deploy" | "call";
 
+export enum TransactionHashVariant {
+  LATEST_FINAL = "latest-final",
+  LATEST_NONFINAL = "latest-nonfinal",
+}
+
 export type DecodedDeployData = {
   code?: Hex;
   constructorArgs?: any; // Type this more strictly if possible

--- a/src/wallet/connect.ts
+++ b/src/wallet/connect.ts
@@ -1,4 +1,6 @@
 import {localnet} from "@/chains/localnet";
+import {studionet} from "@/chains/studionet";
+import {testnetAsimov} from "@/chains/testnetAsimov";
 import {GenLayerClient, GenLayerChain} from "@/types";
 import {Network} from "@/types/network";
 import {SnapSource} from "@/types/snapSource";
@@ -6,17 +8,19 @@ import {snapID} from "@/config/snapID";
 
 const networks = {
   localnet,
+  studionet,
+  testnetAsimov,
 };
 
 export const connect = async (
   client: GenLayerClient<GenLayerChain>,
-  network: Network = "localnet",
+  network: Network = "studionet",
   snapSource: SnapSource = "npm",
 ): Promise<void> => {
   if (!window.ethereum) {
     throw new Error("MetaMask is not installed.");
   }
-  if (network === "testnet" || network === "mainnet") {
+  if (network === "mainnet") {
     throw new Error(`${network} is not available yet. Please use localnet.`);
   }
 


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes DXP-304
Fixes DXP-305
Fixes DXP-306

# What

- Updated `testnet` to `testnetAsimov` across the codebase, including chain configurations, imports, and network types.
- Introduced `studionet` as a new network option and set it as the default network in `connect.ts`.
- Added new contract addresses and ABIs, including `CONSENSUS_MAIN_CONTRACT`.
- Defined new error types and events for contracts.
- Implemented a temporary fix for DXP-298, updating transaction status and decoding for localnet transactions.
- Added a `TransactionHashVariant` enum with `LATEST_FINAL` and `LATEST_NONFINAL` options and integrated it into contract actions.
- Updated the simulator JSON RPC URL and explorer URL for localnet.
- Changed chain name from "Genlayer Testnet" to "Genlayer Asimov Testnet" and updated block explorer details.

# Why

- To align with naming conventions, improve code readability, and ensure consistency across the codebase.
- To provide users with more network options and enhance user experience.
- To update contract information and improve contract functionality.
- To address existing issues (DXP-298) and provide flexibility in transaction handling.
- To ensure accurate communication with the simulator and explorer.

# Testing done

- Tested the new network options (`studionet`, `testnetAsimov`).
- Verified the updated contract addresses, ABIs, error types, and events.
- Tested the DXP-298 fix and localnet transaction handling.
- Tested functionality with different transaction hash variants.
- Verified chain configuration changes and block explorer updates.
- Ran tests to ensure export changes did not introduce issues and checked for impacts on dependent modules.

# Decisions made

- Updated export names and chain variable names (e.g., "testnetAsimov") for clarity and consistency.
- Added a default value for the `transactionHashVariant` parameter to ensure backward compatibility.
- Used a conditional return statement to handle transactions differently based on the chain ID.
- Updated the `Network` type to reflect current network configurations.

# Checks

- [X] I have tested this code
- [X I have reviewed my own PR
- [X] I have created an issue for this PR
- [X] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Focus on the consistency of the `testnetAsimov` and `studionet` integration.
- Check the accuracy of new contract details and the implementation of `TransactionHashVariant`.
- Ensure the DXP-298 fix behaves as expected for localnet transactions.

# User facing release notes

- The "testnet" has been renamed to "testnetAsimov".
- A new "studionet" network option has been added and is now the default connection.
- Users can now specify `LATEST_FINAL` and `LATEST_NONFINAL` transaction hash variants.
- Improved transaction status display and handling for localnet transactions.
- Updated contract addresses and ABIs for improved functionality.
- The chain name is now "Genlayer Asimov Testnet" and the block explorer is "GenLayer Asimov Explorer" at "https://explorer-asimov.genlayer.com/".
