### PR TITLE
fix: remove DXP-298 code

### DIFF
--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -1,5 +1,5 @@
 import * as calldata from "@/abi/calldata";
-import {serialize, serializeOne} from "@/abi/transactions";
+import {serialize} from "@/abi/transactions";
 import {localnet} from "@/chains/localnet";
 import {
   Account,
@@ -9,7 +9,6 @@ import {
   CalldataEncodable,
   Address,
   TransactionHashVariant,
-  TransactionStatus,
 } from "@/types";
 import {fromHex, toHex, zeroAddress, encodeFunctionData, PublicClient, parseEventLogs} from "viem";
 

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -68,7 +68,6 @@ export const receiptActions = (client: GenLayerClient<GenLayerChain>, publicClie
 
 export const transactionActions = (client: GenLayerClient<GenLayerChain>, publicClient: PublicClient) => ({
   getTransaction: async ({hash}: {hash: TransactionHash}): Promise<GenLayerTransaction> => {
-    // TODO: remove this once DXP-298 is merged
     if (client.chain.id === localnet.id) {
       const transaction = await client.getTransaction({hash});
       const localnetStatus =


### PR DESCRIPTION
Fixes #DXP-313

# What

<!-- Describe the changes you made. -->

- Removed the `_localnetReadContract` function and its associated logic from `src/contracts/actions.ts`.
- Removed the conditional check for `localnet.id` in the `_sendTransaction` function.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To clean up the codebase by removing temporary code that was meant to be removed once DXP-298 was merged.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Verified with studio.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the removal of the `_localnetReadContract` function and ensure that no other parts of the code depend on it.
- Verify that the transaction logic works as expected without the localnet-specific condition.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Removed temporary localnet-specific logic from the contract actions.