### PR TITLE
fix: update readContract with TransactionHashVariant

### DIFF
--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -1,5 +1,5 @@
 import {Transport, Client, PublicActions, WalletActions} from "viem";
-import {GenLayerTransaction, TransactionHash, TransactionStatus} from "./transactions";
+import {GenLayerTransaction, TransactionHash, TransactionStatus, TransactionHashVariant} from "./transactions";
 import {GenLayerChain} from "./chains";
 import {Address, Account} from "./accounts";
 import {CalldataEncodable} from "./calldata";
@@ -43,10 +43,10 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       account?: Account;
       address: Address;
       functionName: string;
-      stateStatus?: TransactionStatus;
       args?: CalldataEncodable[];
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
       rawReturn?: RawReturn;
+      transactionHashVariant?: TransactionHashVariant;
     }) => Promise<RawReturn extends true ? `0x${string}` : CalldataEncodable>;
     writeContract: (args: {
       account?: Account;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -4,7 +4,7 @@ import {localnet} from "@/chains/localnet";
 import {Address} from "../src/types/accounts";
 import {createAccount, generatePrivateKey} from "../src/accounts/account";
 import {vi} from "vitest";
-import {TransactionStatus, TransactionHashVariant} from "../src/types/transactions";
+import {TransactionHashVariant} from "../src/types/transactions";
 
 // Setup fetch mock
 const mockFetch = vi.fn();

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -4,7 +4,7 @@ import {localnet} from "@/chains/localnet";
 import {Address} from "../src/types/accounts";
 import {createAccount, generatePrivateKey} from "../src/accounts/account";
 import {vi} from "vitest";
-import {TransactionStatus} from "../src/types/transactions";
+import {TransactionStatus, TransactionHashVariant} from "../src/types/transactions";
 
 // Setup fetch mock
 const mockFetch = vi.fn();
@@ -95,7 +95,7 @@ describe("Client Overrides", () => {
       address: contractAddress as Address,
       functionName: "testFunction",
       args: ["arg1", "arg2"],
-      stateStatus: TransactionStatus.ACCEPTED, // Kept as is, matches type, ignored by current gen_call impl.
+      transactionHashVariant: TransactionHashVariant.LATEST_NONFINAL,
     });
 
     expect(lastGenCallParams).toEqual([
@@ -104,7 +104,7 @@ describe("Client Overrides", () => {
         to: contractAddress,
         from: account.address,
         data: expect.any(String), // The data is complex, checking type is often sufficient
-        transaction_hash_variant: "latest-final",
+        transaction_hash_variant: TransactionHashVariant.LATEST_NONFINAL,
       },
     ]);
   });
@@ -126,7 +126,7 @@ describe("Client Overrides", () => {
       address: contractAddress as Address,
       functionName: "testFunction",
       args: ["arg1", "arg2"],
-      stateStatus: TransactionStatus.ACCEPTED,
+      transactionHashVariant: TransactionHashVariant.LATEST_FINAL,
     });
 
     expect(lastGenCallParams).toEqual([
@@ -135,7 +135,7 @@ describe("Client Overrides", () => {
         to: contractAddress,
         from: overrideAccount.address,
         data: expect.any(String),
-        transaction_hash_variant: "latest-final",
+        transaction_hash_variant: TransactionHashVariant.LATEST_FINAL,
       },
     ]);
   });
@@ -164,7 +164,7 @@ describe("Client Overrides", () => {
         to: contractAddress,
         from: accountAddressString, // Expecting the address string directly
         data: expect.any(String),
-        transaction_hash_variant: "latest-final",
+        transaction_hash_variant: TransactionHashVariant.LATEST_FINAL,
       },
     ]);
   });


### PR DESCRIPTION
Fixes #issue-number-here

# What

<!-- Describe the changes you made. -->

- Replaced `stateStatus` with `transactionHashVariant` in the `GenLayerClient` type definition.
- Updated test cases to use `TransactionHashVariant` instead of `TransactionStatus`.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To update type definition.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Updated and ran existing test cases to verify that the changes to `transactionHashVariant` are correctly implemented and functioning as expected.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the code changes.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Updated readContract to use `TransactionHashVariant` in definition.