### PR TITLE
feat: export studionet as genlayer chain

### DIFF
--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -1,3 +1,4 @@
 // src/chains/index.ts
 export {localnet} from "./localnet";
+export {studionet} from "./studionet";
 export {testnetAsimov} from "./testnetAsimov";


### PR DESCRIPTION

Fixes #DXP-352

# What

- Added export for `studionet` chain configuration in `src/chains/index.ts`

# Why

- To make the Genlayer Studio Network chain configuration available for import and use in applications
- Enables developers to connect to the studio environment at `https://studio.genlayer.com/api`

# Testing done

- Verified the studionet chain configuration is properly exported
- Confirmed the chain configuration includes correct RPC URL, explorer, and contract addresses

# Decisions made

- Added the export alongside existing chain exports (localnet, testnetAsimov) for consistency
- Maintained alphabetical ordering of exports

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [X] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- This is a simple export addition - verify that the studionet configuration is properly accessible when imported

# User facing release notes

- Added support for Genlayer Studio Network chain configuration, allowing developers to connect to the hosted studio environment